### PR TITLE
Add endpoint to check eth node duplicates

### DIFF
--- a/pkg/core/server/eth.go
+++ b/pkg/core/server/eth.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/AudiusProject/audius-protocol/pkg/core/contracts"
+	"github.com/labstack/echo/v4"
 )
 
 func (s *Server) startEthNodeManager() error {
@@ -78,4 +79,17 @@ func (s *Server) gatherEthNodes() error {
 
 func (s *Server) blacklistDuplicateEthNodes() error {
 	return nil
+}
+
+func (s *Server) getEthNodesHandler(c echo.Context) error {
+	s.ethNodeMU.RLock()
+	defer s.ethNodeMU.RUnlock()
+	res := struct {
+		Nodes          []*contracts.Node `json:"nodes"`
+		DuplicateNodes []*contracts.Node `json:"duplicateNodes"`
+	}{
+		Nodes:          s.ethNodes,
+		DuplicateNodes: s.duplicateEthNodes,
+	}
+	return c.JSON(200, res)
 }

--- a/pkg/core/server/http.go
+++ b/pkg/core/server/http.go
@@ -39,6 +39,7 @@ func (s *Server) startEchoServer() error {
 	g.GET("/nodes/discovery/verbose", s.getRegisteredNodes)
 	g.GET("/nodes/content", s.getRegisteredNodes)
 	g.GET("/nodes/content/verbose", s.getRegisteredNodes)
+	g.GET("/nodes/eth", s.getEthNodesHandler)
 
 	if s.config.CometModule {
 		g.Any("/debug/comet*", s.proxyCometRequest)


### PR DESCRIPTION
To help with debugging duplicate node registration issues, this endpoint will confirm whether we have the correct information to prevent a node from registering on comet if it is reusing a key.