### PR TITLE
lower dev timeout for empty block and air for all audiusd nodes

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - core-tests
 
   audiusd-1:
+    container_name: audiusd-1
     image: ${AUDIUSD_IMAGE:-audius/audiusd:dev}
     restart: unless-stopped
     env_file:
@@ -64,6 +65,7 @@ services:
       - core-tests
 
   audiusd-2:
+    container_name: audiusd-2
     image: ${AUDIUSD_IMAGE:-audius/audiusd:dev}
     restart: unless-stopped
     env_file:
@@ -79,11 +81,18 @@ services:
       timeout: 5s
       retries: 3
       start_period: 5s
+    volumes:
+      - ./cmd:/app/cmd
+      - ./pkg:/app/pkg
+      - ./go.mod:/app/go.mod
+      - ./go.sum:/app/go.sum
+      - ./.air.toml:/app/.air.toml
     profiles:
       - audiusd-dev
       - core-tests
 
   audiusd-3:
+    container_name: audiusd-3
     image: ${AUDIUSD_IMAGE:-audius/audiusd:dev}
     restart: unless-stopped
     env_file:
@@ -99,11 +108,18 @@ services:
       timeout: 5s
       retries: 3
       start_period: 5s
+    volumes:
+      - ./cmd:/app/cmd
+      - ./pkg:/app/pkg
+      - ./go.mod:/app/go.mod
+      - ./go.sum:/app/go.sum
+      - ./.air.toml:/app/.air.toml
     profiles:
       - audiusd-dev
       - core-tests
 
   audiusd-4:
+    container_name: audiusd-4
     image: ${AUDIUSD_IMAGE:-audius/audiusd:dev}
     restart: unless-stopped
     env_file:
@@ -119,6 +135,12 @@ services:
       timeout: 5s
       retries: 3
       start_period: 5s
+    volumes:
+      - ./cmd:/app/cmd
+      - ./pkg:/app/pkg
+      - ./go.mod:/app/go.mod
+      - ./go.sum:/app/go.sum
+      - ./.air.toml:/app/.air.toml
     profiles:
       - audiusd-dev
       - core-tests

--- a/pkg/core/config/setup.go
+++ b/pkg/core/config/setup.go
@@ -142,6 +142,9 @@ func SetupNode(logger *common.Logger) (*Config, *cconfig.Config, error) {
 	cometConfig.Consensus.CreateEmptyBlocks = true
 	// empty blocks wait one second to propose since plays should be a steady stream
 	cometConfig.Consensus.CreateEmptyBlocksInterval = 1 * time.Second
+	if envConfig.Environment == "stage" || envConfig.Environment == "dev" {
+		cometConfig.Consensus.CreateEmptyBlocksInterval = 200 * time.Millisecond
+	}
 
 
 	cometConfig.P2P.PexReactor = true


### PR DESCRIPTION
fixes air for all nodes, it was only on one to start
also adds nicer container names for the audiusd nodes
lastly, lowers empty block timeouts for dev and stage to attempt to get under 1 second :scream: 

test:
`make audiusd-dev`