### PR TITLE
audiusd sdk

### DIFF
--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -12,6 +12,8 @@ server {
     listen 80 default_server;
     server_name _;
 
+    client_max_body_size 100M; # Allow uploads up to 100MB
+
     location / {
         return 200 '{"nginx": "http"}';
         add_header Content-Type application/json;
@@ -21,6 +23,8 @@ server {
 server {
     listen 80;
     server_name ~^node(\d+).audiusd.devnet$;
+
+    client_max_body_size 100M; # Allow uploads up to 100MB
 
     location / {
         proxy_pass http://$backend;
@@ -37,6 +41,8 @@ server {
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers off;
 
+    client_max_body_size 100M; # Allow uploads up to 100MB
+
     location / {
         return 200 '{"nginx": "https"}';
         add_header Content-Type application/json;
@@ -52,11 +58,13 @@ server {
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3;
     ssl_prefer_server_ciphers off;
 
+    client_max_body_size 100M; # Allow uploads up to 100MB
+
     location / {
         proxy_pass https://$https_backend;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;
-        
+
         proxy_ssl_verify off;
         proxy_ssl_server_name on;
         proxy_ssl_protocols TLSv1.2 TLSv1.3;

--- a/pkg/core/config/setup.go
+++ b/pkg/core/config/setup.go
@@ -141,7 +141,7 @@ func SetupNode(logger *common.Logger) (*Config, *cconfig.Config, error) {
 	// create empty blocks to continue heartbeat at the same interval
 	cometConfig.Consensus.CreateEmptyBlocks = true
 	// empty blocks wait one second to propose since plays should be a steady stream
-	cometConfig.Consensus.CreateEmptyBlocksInterval = 1 * time.Second
+	cometConfig.Consensus.CreateEmptyBlocksInterval = 200 * time.Millisecond
 
 
 	cometConfig.P2P.PexReactor = true

--- a/pkg/core/sdk/storage.go
+++ b/pkg/core/sdk/storage.go
@@ -1,0 +1,1 @@
+package sdk

--- a/pkg/core/sdk/storage.go
+++ b/pkg/core/sdk/storage.go
@@ -1,1 +1,0 @@
-package sdk

--- a/pkg/integration_tests/upload_stream_test.go
+++ b/pkg/integration_tests/upload_stream_test.go
@@ -1,0 +1,26 @@
+package integrationtests
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/AudiusProject/audiusd/pkg/sdk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorageUpload(t *testing.T) {
+	sdk := sdk.NewAudiusdSDK(nil, sdk.NewStorageSDK("https://node2.audiusd.devnet"))
+	
+	health, err := sdk.Storage().GetHealth()
+	require.Nil(t, err)
+
+	require.Equal(t, health.Data.Healthy, true)
+
+	uploadRes, err := sdk.Storage().UploadAudio("./assets/anxiety-upgrade.mp3")
+	require.Equal(t, len(uploadRes), 1)
+	require.Nil(t, err)
+
+	upload := uploadRes[0]
+
+	require.Equal(t, upload.OrigFileName, "anxiety-upgrade.mp3")
+}

--- a/pkg/sdk/README.md
+++ b/pkg/sdk/README.md
@@ -1,0 +1,2 @@
+# the audiusd sdk
+

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -1,0 +1,23 @@
+package sdk
+
+import "github.com/AudiusProject/audiusd/pkg/core/sdk"
+
+type AudiusdSDK struct {
+	core *sdk.Sdk
+	storage *StorageSDK
+}
+
+func NewAudiusdSDK(core *sdk.Sdk, storage *StorageSDK) *AudiusdSDK {
+	return &AudiusdSDK{
+		core: core,
+		storage: storage,
+	}
+}
+
+func (s *AudiusdSDK) Core() *sdk.Sdk {
+	return s.core
+}
+
+func (s *AudiusdSDK) Storage() *StorageSDK {
+	return s.storage
+}

--- a/pkg/sdk/sdk_test.go
+++ b/pkg/sdk/sdk_test.go
@@ -1,0 +1,13 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSDKHealth(t *testing.T) {
+	storageSDK := NewStorageSDK("https://creatornode.audius.co")
+	_, err := storageSDK.GetHealth()
+	require.Nil(t, err)
+}

--- a/pkg/sdk/storage.go
+++ b/pkg/sdk/storage.go
@@ -1,9 +1,14 @@
 package sdk
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/AudiusProject/audiusd/pkg/mediorum/server"
@@ -57,10 +62,74 @@ func (s *StorageSDK) GetHealth() (*server.HealthCheckResponse, error) {
 	return &healthCheckResponse, nil
 }
 
+func (s *StorageSDK) UploadAudio(filePath string) ([]*server.Upload, error) {
+	// Open the audio file
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
 
-func (s *StorageSDK) UploadAudio() (*server.Upload, error) {
-	return nil, nil
+	// Create a buffer to hold the multipart form data
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	// Create the file field in the multipart form
+	part, err := writer.CreateFormFile("files", filepath.Base(filePath))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create form file: %w", err)
+	}
+
+	// Copy the file data into the form
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to copy file data: %w", err)
+	}
+
+	// Add additional fields (if any)
+	err = writer.WriteField("template", "audio")
+	if err != nil {
+		return nil, fmt.Errorf("failed to write field: %w", err)
+	}
+
+	// Close the writer to finalize the multipart form
+	err = writer.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failed to close writer: %w", err)
+	}
+
+	// Create the HTTP POST request
+	req, err := http.NewRequest("POST", s.nodeURL+"/uploads", &body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	// Set the Content-Type header to the multipart boundary
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	// Execute the request
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check the response status
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("upload failed with status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	// Parse the response body
+	var upload []*server.Upload
+	err = json.NewDecoder(resp.Body).Decode(&upload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return upload, nil
 }
+
 
 func (s *StorageSDK) GetAudio() (*server.Upload, error) {
 	return nil, nil

--- a/pkg/sdk/storage.go
+++ b/pkg/sdk/storage.go
@@ -1,0 +1,67 @@
+package sdk
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/AudiusProject/audiusd/pkg/mediorum/server"
+)
+
+type StorageSDK struct {
+	nodeURL string
+	httpClient *http.Client
+}
+
+func NewStorageSDK(nodeURL string) *StorageSDK {
+	return &StorageSDK{
+		nodeURL: nodeURL,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+func (s *StorageSDK) GetNodeURL() string {
+	return s.nodeURL
+}
+
+func (s *StorageSDK) SetNodeURL(nodeURL string) {
+	s.nodeURL = nodeURL
+}
+
+func (s *StorageSDK) GetHealth() (*server.HealthCheckResponse, error) {
+	req, err := http.NewRequest("GET", s.nodeURL+"/health_check", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var healthCheckResponse server.HealthCheckResponse
+	err = json.Unmarshal(body, &healthCheckResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	return &healthCheckResponse, nil
+}
+
+
+func (s *StorageSDK) UploadAudio() (*server.Upload, error) {
+	return nil, nil
+}
+
+func (s *StorageSDK) GetAudio() (*server.Upload, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Adds an upload function and storage sdk to a higher level audiusd sdk. This can be used to back audiusd-cmd. Track streaming isn't supported yet as that would require some changes to the way streaming works and the related discovery /stream endpoint.

Adds a test for the audiusd sdk as well for upload. Run `make audiusd-dev` and execute that test. I use vscode to run it.

Also increases the nginx config for local to support file sizes higher than 100mb.