### PR TITLE
create Peers and EthNodes structs

### DIFF
--- a/pkg/core/server/auditor.go
+++ b/pkg/core/server/auditor.go
@@ -121,7 +121,7 @@ func (s *Server) shouldProposeNewRollup(ctx context.Context, height int64) bool 
 }
 
 func (s *Server) finalizeSlaRollup(ctx context.Context, event *core_proto.SignedTransaction, txHash string) (*core_proto.SlaRollup, error) {
-	appDb := s.getDb()
+	appDb := s.getFinalizeBlockTransaction()
 	rollup := event.GetSlaRollup()
 
 	id, err := appDb.CommitSlaRollup(

--- a/pkg/core/server/mempool.go
+++ b/pkg/core/server/mempool.go
@@ -171,7 +171,7 @@ func (s *Server) broadcastMempoolTransaction(key string, tx *MempoolTransaction)
 		return
 	}
 
-	peers := s.GetPeers()
+	peers := s.peers.GetPeers()
 	for _, peer := range peers {
 		go func(logger *common.Logger, peer *sdk.Sdk) {
 			params := protocol.NewProtocolForwardTransactionParams()

--- a/pkg/core/server/registry_bridge.go
+++ b/pkg/core/server/registry_bridge.go
@@ -158,7 +158,7 @@ func (s *Server) registerSelfOnComet(ethBlock, spID string) error {
 		}
 	}
 
-	peers := s.GetPeers()
+	peers := s.peers.GetPeers()
 	noPeers := len(peers) == 0
 
 	if !isGenValidator && noPeers {

--- a/pkg/core/server/server.go
+++ b/pkg/core/server/server.go
@@ -37,8 +37,7 @@ type Server struct {
 	rpc   *local.Local
 	mempl *Mempool
 
-	peers   map[string]*sdk.Sdk
-	peersMU sync.RWMutex
+	peers *Peers
 
 	txPubsub *TransactionHashPubsub
 
@@ -76,6 +75,10 @@ func NewServer(config *config.Config, cconfig *cconfig.Config, logger *common.Lo
 	ethNodes := []*contracts.Node{}
 	duplicateEthNodes := []*contracts.Node{}
 
+	peers := &Peers{
+		peers: make(map[string]*sdk.Sdk),
+	}
+
 	s := &Server{
 		config:         config,
 		cometbftConfig: cconfig,
@@ -87,7 +90,7 @@ func NewServer(config *config.Config, cconfig *cconfig.Config, logger *common.Lo
 		db:        db.New(pool),
 		eth:       eth,
 		mempl:     mempl,
-		peers:     make(map[string]*sdk.Sdk),
+		peers:     peers,
 		txPubsub:  txPubsub,
 		cache:     NewCache(),
 		abciState: NewABCIState(),


### PR DESCRIPTION
- Removes the RW locks at the server struct and encapsulates them within context specific structures.
- EthNodes and Peers
- Renames the ABCI block finalize methods to something more descriptive to prevent misuse.