### PR TITLE
fix mediorum with air

### DIFF
--- a/dev/env/audiusd-1.env
+++ b/dev/env/audiusd-1.env
@@ -6,7 +6,7 @@ audius_discprov_url=https://node1.audiusd.devnet
 audius_core_root_dir=./tmp/discoveryOneHome
 audius_delegate_private_key=d09ba371c359f10f22ccda12fd26c598c7921bda3220c9942174562bc6a36fe8
 audius_discprov_env=dev
-audius_db_url=postgres://postgres:postgres@localhost:5432/audius_discovery?sslmode=disable&client_encoding=UTF8
+audius_db_url=postgres://postgres:postgres@localhost:5432/audius_discovery?sslmode=disable
 runDownMigration="true"
 rpcLaddr="tcp://0.0.0.0:26657"
 externalAddress="audiusd-1:26656"

--- a/dev/env/audiusd-2.env
+++ b/dev/env/audiusd-2.env
@@ -6,7 +6,7 @@ creatorNodeEndpoint=https://node2.audiusd.devnet
 audius_core_root_dir=./tmp/content1Home
 delegatePrivateKey=21118f9a6de181061a2abd549511105adb4877cf9026f271092e6813b7cf58ab
 MEDIORUM_ENV=dev
-dbUrl=postgres://postgres:postgres@localhost:5432/audius_creator_node?sslmode=disable&client_encoding=UTF8
+dbUrl=postgres://postgres:postgres@localhost:5432/audius_creator_node?sslmode=disable
 runDownMigration="true"
 rpcLaddr="tcp://0.0.0.0:26657"
 externalAddress="audiusd-2:26656"

--- a/dev/env/audiusd-3.env
+++ b/dev/env/audiusd-3.env
@@ -6,7 +6,7 @@ creatorNodeEndpoint=https://node3.audiusd.devnet
 audius_core_root_dir=./tmp/content3Home
 delegatePrivateKey=1aa14c63d481dcc1185a654eb52c9c0749d07ac8f30ef17d45c3c391d9bf68eb
 MEDIORUM_ENV=dev
-dbUrl=postgres://postgres:postgres@localhost:5432/audius_creator_node?sslmode=disable&client_encoding=UTF8
+dbUrl=postgres://postgres:postgres@localhost:5432/audius_creator_node?sslmode=disable
 runDownMigration="true"
 rpcLaddr="tcp://0.0.0.0:26657"
 externalAddress="audiusd-3:26656"

--- a/dev/env/audiusd-4.env
+++ b/dev/env/audiusd-4.env
@@ -6,7 +6,7 @@ creatorNodeEndpoint=https://node4.audiusd.devnet
 audius_core_root_dir=./tmp/content2Home
 delegatePrivateKey=1166189cdf129cdcb011f2ad0e5be24f967f7b7026d162d7c36073b12020b61c
 MEDIORUM_ENV=dev
-dbUrl=postgres://postgres:postgres@localhost:5432/audius_creator_node?sslmode=disable&client_encoding=UTF8
+dbUrl=postgres://postgres:postgres@localhost:5432/audius_creator_node?sslmode=disable
 runDownMigration="true"
 rpcLaddr="tcp://0.0.0.0:26657"
 externalAddress="audiusd-4:26656"

--- a/pkg/mediorum/server/db.go
+++ b/pkg/mediorum/server/db.go
@@ -137,6 +137,11 @@ func dbMustDial(dbPath string) *gorm.DB {
 	}
 
 	sqlDb, _ := db.DB()
+	// air doesn't reset client connections so this explicitly sets the client encoding
+	_, err = sqlDb.Exec("SET client_encoding TO 'UTF8';")
+	if err != nil {
+		panic(fmt.Sprintf("Failed to set client encoding: %v", err))
+	}
 	sqlDb.SetMaxOpenConns(50)
 
 	// db = db.Debug()

--- a/pkg/mediorum/server/qm_sync.go
+++ b/pkg/mediorum/server/qm_sync.go
@@ -54,7 +54,12 @@ func (ss *MediorumServer) serveInternalQmCsv(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	return c.Stream(200, "text/plain", r)
+	defer r.Close()
+
+	if err := c.Stream(200, "text/plain", r); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (ss *MediorumServer) pullQmFromPeer(host string) error {


### PR DESCRIPTION
- fixes mediorum with air and sets the encoding type explicitly
- removes it in the db url since this wasn't being used
- fixes a reader that was never closed in qm_sync.go