### PR TITLE
Fix legacy .data.version in /health_check

### DIFF
--- a/cmd/audiusd/main.go
+++ b/cmd/audiusd/main.go
@@ -466,6 +466,10 @@ func getHealthCheckResponse(hostUrl *url.URL) map[string]interface{} {
 		"hostname":  hostUrl.Hostname(),
 		"timestamp": time.Now().UTC(),
 		"uptime":    time.Since(startTime).String(),
+		// TODO: legacy version data for uptime health check
+		"data": map[string]interface{}{
+			"version": mediorum.GetVersionJson().Version,
+		},
 	}
 
 	storageResponse := map[string]interface{}{


### PR DESCRIPTION
Core only nodes had broken version info on dashboard.

We should update the versioning strategy overall. But this makes it so it will not display as `!`

**TEST**

```
make audiusd-dev
```

node1 runs as a "core only" node - was not working
```
$ curl -s https://node1.audiusd.devnet/health_check | jq .data.version
"0.7.71"
```

node2 is storage node - was already working
```
$ curl -s https://node2.audiusd.devnet/health_check | jq .data.version
"0.7.71"
```