### PR TITLE
remove defaults in .env files

### DIFF
--- a/cmd/audiusd/env/dev.env
+++ b/cmd/audiusd/env/dev.env
@@ -1,3 +1,1 @@
 MEDIORUM_ENV=dev
-audius_core_root_dir=/audius-core
-uptimeDataDir=/bolt

--- a/cmd/audiusd/env/prod.env
+++ b/cmd/audiusd/env/prod.env
@@ -1,6 +1,4 @@
 POSTGRES_DATA_DIR=/data/postgres
-audius_core_root_dir=/audius-core
-uptimeDataDir=/bolt
 
 MEDIORUM_ENV=prod
 audius_discprov_env=prod

--- a/cmd/audiusd/env/stage.env
+++ b/cmd/audiusd/env/stage.env
@@ -1,6 +1,4 @@
 POSTGRES_DATA_DIR=/data/postgres
-audius_core_root_dir=/audius-core
-uptimeDataDir=/bolt
 
 MEDIORUM_ENV=stage
 audius_discprov_env=stage


### PR DESCRIPTION
I believe there's already defaults in the `entrypoint.sh` as well as the `config.go` file itself. If you try to set these not in an override.env those values aren't respected.