### PR TITLE
Allow setting of envs for audius-docker-compose yaml files

### DIFF
--- a/pkg/conf/model.go
+++ b/pkg/conf/model.go
@@ -69,6 +69,9 @@ type NodeConfig struct {
 	// (EXPERIMENTAL) Path on host machine to env file containing additional private configuration
 	RemoteConfigFile string `yaml:"remoteConfigFile,omitempty"`
 
+	// Environment variables for the audius-d wrapper container
+	AudiusDockerComposeConfig map[string]string `yaml:"audiusDockerComposeConfig,omitempty"`
+
 	PluginsConfig map[PluginName]map[string]string `yaml:"plugins,omitempty"`
 }
 

--- a/pkg/orchestration/docker.go
+++ b/pkg/orchestration/docker.go
@@ -102,6 +102,14 @@ func runNode(
 	containerConfig := &container.Config{
 		Image: fmt.Sprintf("audius/audius-d:%s", audiusdTag),
 	}
+
+	if len(config.AudiusDockerComposeConfig) > 0 {
+		containerConfig.Env = make([]string, 0, len(config.AudiusDockerComposeConfig))
+		for key, value := range config.AudiusDockerComposeConfig {
+			containerConfig.Env = append(containerConfig.Env, fmt.Sprintf("%s=%s", key, value))
+		}
+	}
+
 	hostConfig := &container.HostConfig{
 		Privileged: true,
 		Mounts: []mount.Mount{


### PR DESCRIPTION
In some cases like [this](https://github.com/AudiusProject/audius-docker-compose/blob/stage/discovery-provider/docker-compose.yml#L145) we need to set envs for the wrapper container.
This add allows that.

Furthermore, given the in flux state of `audius-ctl` between repos. I manually published a release to the protocol repo here https://github.com/AudiusProject/audius-protocol/releases/tag/audius-ctl%400.1.106

**HOW WAS THIS TESTED**

Added a section to contexts for adc config [here](https://github.com/AudiusProject/audius-ssh/commit/282257b8440e3d0dca865108a416752513894521)

```
...
  audiusDockerComposeConfig:
    SERVER_MEM_LIMIT: "8g"
...
```

Update audius-ctl from latest published release.

```
# update audius-ctl
curl -sSL https://install.audius.org/ | sh

# check version
audius-ctl --version 
0.1.106
```

Then re up and jump to that box. Inspect env...

```
audius-ctl up discoveryprovider2.audius.co
audius-ctl jump discoveryprovider2.audius.co
...
0caa49ca78cc:~/audius-docker-compose# env | grep MEM
SERVER_MEM_LIMIT=8g
```

Docker stats inside the wrapper then shows correct MEM limit
```
22414a71c19d   server          47.73%    2.722GiB / 8GiB       34.03%    3.32GB / 2.82GB   4.71MB / 5.19MB   12
```