### PR TITLE
fix no rows result for indexers

### DIFF
--- a/pkg/core/server/grpc.go
+++ b/pkg/core/server/grpc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/AudiusProject/audiusd/pkg/core/common"
 	"github.com/AudiusProject/audiusd/pkg/core/gen/core_proto"
 	"github.com/iancoleman/strcase"
+	"github.com/jackc/pgx/v5"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -147,26 +148,22 @@ func (s *Server) GetBlock(ctx context.Context, req *core_proto.GetBlockRequest) 
 		}, nil
 	}
 
-	// TODO: change this to db call after mainnet-alpha / indexers move along
-	block, err := s.rpc.Block(ctx, &req.Height)
+	block, err := s.db.GetBlock(ctx, req.Height)
 	if err != nil {
-		blockInFutureMsg := "must be less than or equal to the current blockchain height"
-		if strings.Contains(err.Error(), blockInFutureMsg) {
-			// return block with -1 to indicate it doesn't exist yet
-			return &core_proto.BlockResponse{
-				Chainid:       s.config.GenesisFile.ChainID,
-				Height:        -1,
-				CurrentHeight: currentHeight,
-			}, nil
+		if errors.Is(err, pgx.ErrNoRows) {
+			// fallback to rpc for now, remove after mainnet-alpha
+			return s.getBlockRpcFallback(ctx, req.Height)
 		}
 		s.logger.Errorf("error getting block: %v", err)
 		return nil, err
 	}
 
+	blockTxs, err := s.db.GetBlockTransactions(ctx, req.Height)
+
 	txs := []*core_proto.SignedTransaction{}
-	for _, tx := range block.Block.Txs {
+	for _, tx := range blockTxs {
 		var transaction core_proto.SignedTransaction
-		err = proto.Unmarshal(tx, &transaction)
+		err = proto.Unmarshal(tx.Transaction, &transaction)
 		if err != nil {
 			return nil, err
 		}
@@ -174,13 +171,13 @@ func (s *Server) GetBlock(ctx context.Context, req *core_proto.GetBlockRequest) 
 	}
 
 	res := &core_proto.BlockResponse{
-		Blockhash:     block.BlockID.Hash.String(),
+		Blockhash:     block.Hash,
 		Chainid:       s.config.GenesisFile.ChainID,
-		Proposer:      block.Block.ProposerAddress.String(),
-		Height:        block.Block.Height,
+		Proposer:      block.Proposer,
+		Height:        block.Height,
 		Transactions:  txs,
 		CurrentHeight: currentHeight,
-		Timestamp:     timestamppb.New(block.Block.Time),
+		Timestamp:     timestamppb.New(block.CreatedAt.Time),
 	}
 
 	return res, nil
@@ -226,4 +223,45 @@ func (s *Server) startGRPC() error {
 		return err
 	}
 	return nil
+}
+
+// Utilities
+func (s *Server) getBlockRpcFallback(ctx context.Context, height int64) (*core_proto.BlockResponse, error) {
+	currentHeight := s.cache.currentHeight
+	block, err := s.rpc.Block(ctx, &height)
+	if err != nil {
+		blockInFutureMsg := "must be less than or equal to the current blockchain height"
+		if strings.Contains(err.Error(), blockInFutureMsg) {
+			// return block with -1 to indicate it doesn't exist yet
+			return &core_proto.BlockResponse{
+				Chainid:       s.config.GenesisFile.ChainID,
+				Height:        -1,
+				CurrentHeight: currentHeight,
+			}, nil
+		}
+		s.logger.Errorf("error getting block: %v", err)
+		return nil, err
+	}
+
+	txs := []*core_proto.SignedTransaction{}
+	for _, tx := range block.Block.Txs {
+		var transaction core_proto.SignedTransaction
+		err = proto.Unmarshal(tx, &transaction)
+		if err != nil {
+			return nil, err
+		}
+		txs = append(txs, &transaction)
+	}
+
+	res := &core_proto.BlockResponse{
+		Blockhash:     block.BlockID.Hash.String(),
+		Chainid:       s.config.GenesisFile.ChainID,
+		Proposer:      block.Block.ProposerAddress.String(),
+		Height:        block.Block.Height,
+		Transactions:  txs,
+		CurrentHeight: currentHeight,
+		Timestamp:     timestamppb.New(block.Block.Time),
+	}
+
+	return res, nil
 }


### PR DESCRIPTION
Nodes that are indexing plays might hit a block that doesn't exist in the db. This is a product of the previous abci change. This puts a fallback so nodes can pick up blocks that weren't included in the db. Once nodes are past the point of indexing from blocks confirmed in the db we can revert this change or add controls to it.

**How this was tested**
Running live on tikilabs cn1. You can see that this endpoint is able to correctly fallback to block 1 using the inner rpc.
https://audius-cn1.tikilabs.com/core/grpc/block/1
Discovery provider 2 cannot serve this block because it gets a no rows result error.
https://discoveryprovider2.audius.co/core/grpc/block/1