### PR TITLE
Buffered channel to prevent PoSt lockup

### DIFF
--- a/pkg/core/server/pos.go
+++ b/pkg/core/server/pos.go
@@ -50,7 +50,7 @@ func blockShouldTriggerNewPoSChallenge(blockHash []byte) bool {
 }
 
 func (s *Server) sendPoSChallengeToMediorum(blockHash []byte, blockHeight int64) {
-	respChannel := make(chan pos.PoSResponse)
+	respChannel := make(chan pos.PoSResponse, 1)
 	posReq := pos.PoSRequest{
 		Hash:     blockHash,
 		Height:   blockHeight,


### PR DESCRIPTION
Proof-of-storage is likely locking up on staging due to unbuffered channels. If mediorum tries to send a response after core has already timed out, the PoSt goroutine on the mediorum side will never unblock.

We do not see the problematic behavior running local devnet regardless of the fix, but you can still ensure things are working by running:

```
make audiusd-dev && sleep 5 && go test -count=1 ./pkg/integration_tests/
```