### PR TITLE
Remove abci dependence on pos_challenges table

### DIFF
--- a/pkg/core/db/models.go
+++ b/pkg/core/db/models.go
@@ -11,48 +11,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-type ChallengeStatus string
-
-const (
-	ChallengeStatusUnresolved ChallengeStatus = "unresolved"
-	ChallengeStatusComplete   ChallengeStatus = "complete"
-)
-
-func (e *ChallengeStatus) Scan(src interface{}) error {
-	switch s := src.(type) {
-	case []byte:
-		*e = ChallengeStatus(s)
-	case string:
-		*e = ChallengeStatus(s)
-	default:
-		return fmt.Errorf("unsupported scan type for ChallengeStatus: %T", src)
-	}
-	return nil
-}
-
-type NullChallengeStatus struct {
-	ChallengeStatus ChallengeStatus
-	Valid           bool // Valid is true if ChallengeStatus is not NULL
-}
-
-// Scan implements the Scanner interface.
-func (ns *NullChallengeStatus) Scan(value interface{}) error {
-	if value == nil {
-		ns.ChallengeStatus, ns.Valid = "", false
-		return nil
-	}
-	ns.Valid = true
-	return ns.ChallengeStatus.Scan(value)
-}
-
-// Value implements the driver Valuer interface.
-func (ns NullChallengeStatus) Value() (driver.Value, error) {
-	if !ns.Valid {
-		return nil, nil
-	}
-	return string(ns.ChallengeStatus), nil
-}
-
 type ProofStatus string
 
 const (
@@ -140,13 +98,6 @@ type CoreValidator struct {
 	CometPubKey  string
 }
 
-type PosChallenge struct {
-	ID              int32
-	BlockHeight     int64
-	ProverAddresses []string
-	Status          ChallengeStatus
-}
-
 type SlaNodeReport struct {
 	ID             int32
 	Address        string
@@ -171,4 +122,10 @@ type StorageProof struct {
 	Proof           pgtype.Text
 	ProverAddresses []string
 	Status          ProofStatus
+}
+
+type StorageProofPeer struct {
+	ID              int32
+	BlockHeight     int64
+	ProverAddresses []string
 }

--- a/pkg/core/db/reads.sql.go
+++ b/pkg/core/db/reads.sql.go
@@ -181,35 +181,6 @@ func (q *Queries) GetInProgressRollupReports(ctx context.Context) ([]SlaNodeRepo
 	return items, nil
 }
 
-const getIncompletePoSChallenges = `-- name: GetIncompletePoSChallenges :many
-select id, block_height, prover_addresses, status from pos_challenges where status = 'incomplete'
-`
-
-func (q *Queries) GetIncompletePoSChallenges(ctx context.Context) ([]PosChallenge, error) {
-	rows, err := q.db.Query(ctx, getIncompletePoSChallenges)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []PosChallenge
-	for rows.Next() {
-		var i PosChallenge
-		if err := rows.Scan(
-			&i.ID,
-			&i.BlockHeight,
-			&i.ProverAddresses,
-			&i.Status,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getLatestAppState = `-- name: GetLatestAppState :one
 select block_height, app_hash
 from core_app_state
@@ -304,22 +275,6 @@ func (q *Queries) GetNodesByEndpoints(ctx context.Context, dollar_1 []string) ([
 		return nil, err
 	}
 	return items, nil
-}
-
-const getPoSChallenge = `-- name: GetPoSChallenge :one
-select id, block_height, prover_addresses, status from pos_challenges where block_height = $1
-`
-
-func (q *Queries) GetPoSChallenge(ctx context.Context, blockHeight int64) (PosChallenge, error) {
-	row := q.db.QueryRow(ctx, getPoSChallenge, blockHeight)
-	var i PosChallenge
-	err := row.Scan(
-		&i.ID,
-		&i.BlockHeight,
-		&i.ProverAddresses,
-		&i.Status,
-	)
-	return i, err
 }
 
 const getPreviousSlaRollupFromId = `-- name: GetPreviousSlaRollupFromId :one
@@ -718,6 +673,17 @@ func (q *Queries) GetStorageProof(ctx context.Context, arg GetStorageProofParams
 		&i.Status,
 	)
 	return i, err
+}
+
+const getStorageProofPeers = `-- name: GetStorageProofPeers :one
+select prover_addresses from storage_proof_peers where block_height = $1
+`
+
+func (q *Queries) GetStorageProofPeers(ctx context.Context, blockHeight int64) ([]string, error) {
+	row := q.db.QueryRow(ctx, getStorageProofPeers, blockHeight)
+	var prover_addresses []string
+	err := row.Scan(&prover_addresses)
+	return prover_addresses, err
 }
 
 const getStorageProofs = `-- name: GetStorageProofs :many

--- a/pkg/core/db/sql/migrations/00013_proof_of_storage.sql
+++ b/pkg/core/db/sql/migrations/00013_proof_of_storage.sql
@@ -37,3 +37,5 @@ drop table if exists pos_challenges;
 drop table if exists storage_proofs;
 drop type if exists challenge_status;
 drop type if exists proof_status;
+drop index if exists idx_pos_challenges_block_height;
+drop index if exists idx_storage_proofs_block_height;

--- a/pkg/core/db/sql/migrations/00014_proof_of_storage_peers.sql
+++ b/pkg/core/db/sql/migrations/00014_proof_of_storage_peers.sql
@@ -1,0 +1,19 @@
+-- +migrate Up
+
+drop table if exists pos_challenges;
+drop type if exists challenge_status;
+drop index if exists idx_pos_challenges_block_height;
+
+-- This table should be excluded from the abci app state.
+-- Storage nodes will track peers for proof of storage challenges and use this to reject spurious provers.
+create table storage_proof_peers(
+  id serial primary key,
+  block_height bigint not null unique,
+  prover_addresses text[] not null
+);
+
+create index idx_storage_proof_peers_block_height on storage_proof_peers(block_height desc);
+
+-- +migrate Down
+drop table if exists storage_proof_peers;
+drop index if exists idx_storage_proof_peers_block_height;

--- a/pkg/core/db/sql/reads.sql
+++ b/pkg/core/db/sql/reads.sql
@@ -152,11 +152,8 @@ select * from core_transactions where block_id = $1 order by created_at desc;
 -- name: GetBlock :one
 select * from core_blocks where height = $1;
 
--- name: GetIncompletePoSChallenges :many
-select * from pos_challenges where status = 'incomplete';
-
--- name: GetPoSChallenge :one
-select * from pos_challenges where block_height = $1;
+-- name: GetStorageProofPeers :one
+select prover_addresses from storage_proof_peers where block_height = $1;
 
 -- name: GetStorageProof :one
 select * from storage_proofs where block_height = $1 and address = $2;

--- a/pkg/core/db/sql/writes.sql
+++ b/pkg/core/db/sql/writes.sql
@@ -47,19 +47,9 @@ values ($1, $2, $3, $4, $5);
 insert into core_transactions (block_id, index, tx_hash, transaction, created_at)
 values ($1, $2, $3, $4, $5);
 
--- name: InsertPoSChallenge :exec
-insert into pos_challenges (block_height)
-values ($1);
-
--- name: UpdatePoSChallengeProvers :exec
-update pos_challenges
-set prover_addresses = $1
-where block_height = $2;
-
--- name: CompletePoSChallenge :exec
-update pos_challenges
-set status = 'complete'
-where block_height = $1;
+-- name: InsertStorageProofPeers :exec
+insert into storage_proof_peers (block_height, prover_addresses)
+values ($1, $2);
 
 -- name: InsertStorageProof :exec
 insert into storage_proofs (block_height, address, cid, proof_signature, prover_addresses)

--- a/pkg/core/db/writes.sql.go
+++ b/pkg/core/db/writes.sql.go
@@ -62,17 +62,6 @@ func (q *Queries) CommitSlaRollup(ctx context.Context, arg CommitSlaRollupParams
 	return id, err
 }
 
-const completePoSChallenge = `-- name: CompletePoSChallenge :exec
-update pos_challenges
-set status = 'complete'
-where block_height = $1
-`
-
-func (q *Queries) CompletePoSChallenge(ctx context.Context, blockHeight int64) error {
-	_, err := q.db.Exec(ctx, completePoSChallenge, blockHeight)
-	return err
-}
-
 const deleteRegisteredNode = `-- name: DeleteRegisteredNode :exec
 delete from core_validators
 where comet_address = $1
@@ -95,16 +84,6 @@ type InsertFailedStorageProofParams struct {
 
 func (q *Queries) InsertFailedStorageProof(ctx context.Context, arg InsertFailedStorageProofParams) error {
 	_, err := q.db.Exec(ctx, insertFailedStorageProof, arg.BlockHeight, arg.Address)
-	return err
-}
-
-const insertPoSChallenge = `-- name: InsertPoSChallenge :exec
-insert into pos_challenges (block_height)
-values ($1)
-`
-
-func (q *Queries) InsertPoSChallenge(ctx context.Context, blockHeight int64) error {
-	_, err := q.db.Exec(ctx, insertPoSChallenge, blockHeight)
 	return err
 }
 
@@ -159,6 +138,21 @@ func (q *Queries) InsertStorageProof(ctx context.Context, arg InsertStorageProof
 		arg.ProofSignature,
 		arg.ProverAddresses,
 	)
+	return err
+}
+
+const insertStorageProofPeers = `-- name: InsertStorageProofPeers :exec
+insert into storage_proof_peers (block_height, prover_addresses)
+values ($1, $2)
+`
+
+type InsertStorageProofPeersParams struct {
+	BlockHeight     int64
+	ProverAddresses []string
+}
+
+func (q *Queries) InsertStorageProofPeers(ctx context.Context, arg InsertStorageProofPeersParams) error {
+	_, err := q.db.Exec(ctx, insertStorageProofPeers, arg.BlockHeight, arg.ProverAddresses)
 	return err
 }
 
@@ -230,22 +224,6 @@ func (q *Queries) StoreTransaction(ctx context.Context, arg StoreTransactionPara
 		arg.Transaction,
 		arg.CreatedAt,
 	)
-	return err
-}
-
-const updatePoSChallengeProvers = `-- name: UpdatePoSChallengeProvers :exec
-update pos_challenges
-set prover_addresses = $1
-where block_height = $2
-`
-
-type UpdatePoSChallengeProversParams struct {
-	ProverAddresses []string
-	BlockHeight     int64
-}
-
-func (q *Queries) UpdatePoSChallengeProvers(ctx context.Context, arg UpdatePoSChallengeProversParams) error {
-	_, err := q.db.Exec(ctx, updatePoSChallengeProvers, arg.ProverAddresses, arg.BlockHeight)
 	return err
 }
 


### PR DESCRIPTION
Because the pos_challenge table is not deterministically updated, it should not be used as part of the abci. This change drops that table and creates a simpler one explicitly for the optional storage of prover peers. This table continues doing the job of excluding spurious provers from storage challenges, but is no longer strictly necessary for abci consensus.

Tested by ensuring PoSt challenges still work:

```
make audiusd-dev && sleep 5 && go test -count=1 ./pkg/integration_tests/
# then check postgres for a gradual accumulation of passed storage_proofs and storage_proof_peers
```