### PR TITLE
rm other providers

### DIFF
--- a/pkg/registrar/multi.go
+++ b/pkg/registrar/multi.go
@@ -10,8 +10,6 @@ import (
 func NewMultiStaging() PeerProvider {
 	return multiProvider{
 		providers: []PeerProvider{
-			NewAudiusApiGatewayStaging(),
-			NewGraphStaging(),
 			NewEthChainProvider(),
 		},
 	}
@@ -21,8 +19,6 @@ func NewMultiStaging() PeerProvider {
 func NewMultiProd() PeerProvider {
 	return multiProvider{
 		providers: []PeerProvider{
-			NewAudiusApiGatewayProd(),
-			NewGraphProd(),
 			NewEthChainProvider(),
 		},
 	}


### PR DESCRIPTION
- rms other providers for eth node registration

**How was this tested**
running actively on tikilabs cn1