### PR TITLE
Enable proof of storage on prod

### DIFF
--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -195,7 +195,7 @@ func ReadConfig(logger *common.Logger) (*Config, error) {
 
 		cfg.SlaRollupInterval = mainnetRollupInterval
 		cfg.ValidatorVotingPower = mainnetValidatorVotingPower
-		cfg.EnablePoS = false
+		cfg.EnablePoS = true
 
 	case "stage", "staging", "testnet":
 		cfg.PersistentPeers = GetEnvWithDefault("persistentPeers", moduloPersistentPeers(ethAddress, StagePersistentPeers, 3))


### PR DESCRIPTION
This has been running fairly smoothly on staging, we are ready to switch it on for production.