### PR TITLE
Increase timeout waiting for mediorum response.

### DIFF
--- a/pkg/core/server/pos.go
+++ b/pkg/core/server/pos.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	mediorumPoSRequestTimeout = 1 * time.Second
+	mediorumPoSRequestTimeout = 3 * time.Second
 	posChallengeDeadline      = 2
 	posVerificationDelay      = posChallengeDeadline * 3 * time.Second
 )


### PR DESCRIPTION
The mediorum request to get information about a proof of storage challenge is non-blocking. We can give it additional time to respond just in case legitimate proofs are being skipped for whatever reason.