### PR TITLE
Add transcode stats to health check endpoint.

### DIFF
--- a/pkg/mediorum/server/monitor.go
+++ b/pkg/mediorum/server/monitor.go
@@ -73,10 +73,11 @@ func (ss *MediorumServer) recordStorageAndDbSize() {
 	}
 }
 
-func (ss *MediorumServer) monitorDiskAndDbStatus() {
+func (ss *MediorumServer) monitorMetrics() {
 	// retry a few times to get initial status on startup
 	for i := 0; i < 3; i++ {
 		ss.updateDiskAndDbStatus()
+		ss.updateTranscodeStats()
 		time.Sleep(time.Minute)
 	}
 
@@ -86,6 +87,7 @@ func (ss *MediorumServer) monitorDiskAndDbStatus() {
 	ticker := time.NewTicker(10 * time.Minute)
 	for range ticker.C {
 		ss.updateDiskAndDbStatus()
+		ss.updateTranscodeStats()
 	}
 }
 

--- a/pkg/mediorum/server/serve_health.go
+++ b/pkg/mediorum/server/serve_health.go
@@ -60,6 +60,8 @@ type HealthCheckResponseData struct {
 	IsDbLocalhost             bool                       `json:"isDbLocalhost"`
 	DiskHasSpace              bool                       `json:"diskHasSpace"`
 	IsDiscoveryListensEnabled bool                       `json:"isDiscoveryListensEnabled"`
+	TranscodeQueueLength      int                        `json:"transcodeQueueLength"`
+	TranscodeStats            *TranscodeStats            `json:"transcodeStats"`
 }
 
 func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
@@ -123,6 +125,8 @@ func (ss *MediorumServer) serveHealthCheck(c echo.Context) error {
 		IsDbLocalhost:             ss.Config.PostgresDSN == "postgres://postgres:postgres@db:5432/audius_creator_node" || ss.Config.PostgresDSN == "postgresql://postgres:postgres@db:5432/audius_creator_node" || ss.Config.PostgresDSN == "localhost",
 		IsDiscoveryListensEnabled: ss.Config.discoveryListensEnabled(),
 		DiskHasSpace:              ss.diskHasSpace(),
+		TranscodeQueueLength:      len(ss.transcodeWork),
+		TranscodeStats:            ss.getTranscodeStats(),
 	}
 
 	dataBytes, err := json.Marshal(data)

--- a/pkg/mediorum/server/serve_upload_test.go
+++ b/pkg/mediorum/server/serve_upload_test.go
@@ -42,6 +42,14 @@ func TestUploadFile(t *testing.T) {
 
 	assert.Equal(t, u2.TranscodeProgress, 1.0)
 	assert.Len(t, u2.TranscodedMirrors, s1.Config.ReplicationFactor)
+	assert.Equal(t, u2.TranscodedBy, s1.Config.Self.Host)
+
+	// check transcode stats
+	{
+		s1stats := s1.updateTranscodeStats()
+		assert.Equal(t, 1, s1stats.UploadCount)
+		assert.Greater(t, s1stats.MinTranscodeTime, 0.1)
+	}
 
 	// test preview
 

--- a/pkg/mediorum/server/server.go
+++ b/pkg/mediorum/server/server.go
@@ -89,7 +89,9 @@ type MediorumServer struct {
 	rendezvousHasher *RendezvousHasher
 	transcodeWork    chan *Upload
 
-	// simplify
+	// stats
+	statsMutex       sync.RWMutex
+	transcodeStats   *TranscodeStats
 	mediorumPathUsed uint64
 	mediorumPathSize uint64
 	mediorumPathFree uint64
@@ -539,7 +541,7 @@ func (ss *MediorumServer) MustStart() {
 		}()
 	}
 
-	go ss.monitorDiskAndDbStatus()
+	go ss.monitorMetrics()
 
 	go ss.monitorPeerReachability()
 

--- a/pkg/mediorum/server/transcode_stats.go
+++ b/pkg/mediorum/server/transcode_stats.go
@@ -1,0 +1,51 @@
+package server
+
+import "time"
+
+type TranscodeStats struct {
+	Since              time.Time `db:"since"`
+	UploadCount        int       `db:"upload_count"`
+	MinTranscodeTime   float64   `db:"min_transcode_time"`
+	AvgTranscodeTime   float64   `db:"avg_transcode_time"`
+	MaxTranscodeTime   float64   `db:"max_transcode_time"`
+	TotalTranscodeTime float64   `db:"total_transcode_time"`
+	TotalBytes         int       `db:"total_bytes"`
+	TranscodeRate      float64   `db:"transcode_rate"`
+}
+
+func (ss *MediorumServer) updateTranscodeStats() *TranscodeStats {
+	var stats *TranscodeStats
+	err := ss.crud.DB.Raw(`
+	select
+		NOW() - INTERVAL '10 days' as since,
+		count(*) as upload_count,
+		extract(epoch FROM min(transcoded_at - created_at)) as min_transcode_time,
+		extract(epoch FROM avg(transcoded_at - created_at)) as avg_transcode_time,
+		extract(epoch FROM max(transcoded_at - created_at)) as max_transcode_time,
+		extract(epoch FROM sum(transcoded_at - created_at)) as total_transcode_time,
+		sum((ff_probe::json->'format'->>'size')::int) as total_bytes,
+		sum((ff_probe::json->'format'->>'size')::int) / extract(epoch FROM sum(transcoded_at - created_at)) as transcode_rate
+	from uploads
+	where template = 'audio'
+		and created_at > NOW() - INTERVAL '10 days'
+		and created_by = transcoded_by
+		and created_by = ?
+	`, ss.Config.Self.Host).Scan(&stats).Error
+
+	if err != nil {
+		ss.logger.Error("transcode stats query failed", "err", err)
+	}
+
+	// set pointer
+	ss.statsMutex.Lock()
+	ss.transcodeStats = stats
+	ss.statsMutex.Unlock()
+
+	return stats
+}
+
+func (ss *MediorumServer) getTranscodeStats() *TranscodeStats {
+	ss.statsMutex.RLock()
+	defer ss.statsMutex.RUnlock()
+	return ss.transcodeStats
+}


### PR DESCRIPTION
Clients can use to avoid slow upload experiences.