### PR TITLE
ignore registration validation on old blocks

### DIFF
--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -129,7 +129,7 @@ func ReadConfig(logger *common.Logger) (*Config, error) {
 
 	var cfg Config
 	// comet config
-	cfg.CometLogLevel = GetEnvWithDefault("audius_comet_log_level", "p2p:info,mempool:none,rpc:none,*:error")
+	cfg.CometLogLevel = GetEnvWithDefault("audius_comet_log_level", "p2p:none,mempool:none,rpc:none,*:error")
 	cfg.RootDir = GetEnvWithDefault("audius_core_root_dir", homeDir+"/.audiusd")
 	cfg.RPCladdr = GetEnvWithDefault("rpcLaddr", "tcp://0.0.0.0:26657")
 	cfg.P2PLaddr = GetEnvWithDefault("p2pLaddr", "tcp://0.0.0.0:26656")

--- a/pkg/core/server/registry_bridge.go
+++ b/pkg/core/server/registry_bridge.go
@@ -503,9 +503,13 @@ func (s *Server) isDuplicateDelegateOwnerWallet(delegateOwnerWallet string) erro
 }
 
 // persists the register node request should it pass validation
-func (s *Server) finalizeRegisterNode(ctx context.Context, tx *core_proto.SignedTransaction) (*core_proto.ValidatorRegistration, error) {
-	if err := s.isValidRegisterNodeTx(tx); err != nil {
-		return nil, fmt.Errorf("invalid register node tx: %v", err)
+func (s *Server) finalizeRegisterNode(ctx context.Context, tx *core_proto.SignedTransaction, blockTime time.Time) (*core_proto.ValidatorRegistration, error) {
+	// TODO: remove logic after validator registration switches to attestations
+	oldBlock := time.Since(blockTime) >= week
+	if !oldBlock {
+		if err := s.isValidRegisterNodeTx(tx); err != nil {
+			return nil, fmt.Errorf("invalid register node tx: %v", err)
+		}
 	}
 
 	qtx := s.getDb()


### PR DESCRIPTION
- Ignores validating the ValidatorRegistration tx type for old blocks because this calls out to eth and state can change. This is safe because to even enter this history you need to get consensus in the first place.
- The future attestation mechanism will be resilient to these kinds of changes.

** testing instructions **
Ran a local node against prod, broken nodes halt at 1946 where a creatorseed node was registered. They are no longer on eth.
With the change we get further than this block and they show up in the registered nodes as they previously did in the history.
![Screenshot 2025-02-19 at 12 20 29 PM](https://github.com/user-attachments/assets/02d59cd6-5bea-41e7-b410-1e074ed1666c)
![Screenshot 2025-02-19 at 12 20 42 PM](https://github.com/user-attachments/assets/6a7122de-da89-467d-a209-474d92a58803)

