### PR TITLE
graphql play subscriptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,7 @@ $(PROTO_ARTIFACTS): $(PROTO_SRCS)
 	cd pkg/core/gen/core_proto && swagger generate client -f protocol.swagger.json -t ../ --client-package=core_openapi
 
 .PHONY: regen-gql
-regen-gql: $(GQL_ARTIFACTS)
-$(GQL_ARTIFACTS): $(GQL_SRCS)
+regen-gql:
 	@echo Regenerating gql code
 	cd pkg/core/gql && gqlgen generate
 

--- a/pkg/core/gen/core_gql/models_gen.go
+++ b/pkg/core/gen/core_gql/models_gen.go
@@ -37,6 +37,14 @@ type NodeUptime struct {
 	ReportHistory []*SLAReport `json:"reportHistory"`
 }
 
+type PlayEvent struct {
+	UserID    string `json:"userId"`
+	City      string `json:"city"`
+	Country   string `json:"country"`
+	Region    string `json:"region"`
+	Timestamp string `json:"timestamp"`
+}
+
 type Query struct {
 }
 
@@ -77,6 +85,9 @@ type StorageProof struct {
 	Status         string  `json:"status"`
 	ProofSignature *string `json:"proofSignature,omitempty"`
 	Proof          *string `json:"proof,omitempty"`
+}
+
+type Subscription struct {
 }
 
 type Transaction struct {

--- a/pkg/core/gql/gql.go
+++ b/pkg/core/gql/gql.go
@@ -5,6 +5,7 @@ import (
 	"github.com/AudiusProject/audiusd/pkg/core/config"
 	"github.com/AudiusProject/audiusd/pkg/core/db"
 	"github.com/AudiusProject/audiusd/pkg/core/gen/core_gql"
+	"github.com/AudiusProject/audiusd/pkg/core/pubsub"
 )
 
 // This file will not be regenerated automatically.
@@ -14,15 +15,17 @@ import (
 var _ core_gql.ResolverRoot = &GraphQLServer{}
 
 type GraphQLServer struct {
-	config *config.Config
-	logger *common.Logger
-	db     *db.Queries
+	config      *config.Config
+	logger      *common.Logger
+	db          *db.Queries
+	playsPubsub *pubsub.PlaysPubsub
 }
 
-func NewGraphQLServer(config *config.Config, logger *common.Logger, db *db.Queries) *GraphQLServer {
+func NewGraphQLServer(config *config.Config, logger *common.Logger, db *db.Queries, playsPubsub *pubsub.PlaysPubsub) *GraphQLServer {
 	return &GraphQLServer{
-		config: config,
-		logger: logger,
-		db:     db,
+		config:      config,
+		logger:      logger,
+		db:          db,
+		playsPubsub: playsPubsub,
 	}
 }

--- a/pkg/core/gql/schema.graphqls
+++ b/pkg/core/gql/schema.graphqls
@@ -116,3 +116,15 @@ type Query {
   getNodeUptime(address: String!, rollupId: Int): NodeUptime
   getAllValidatorUptimes(rollupId: Int): [NodeUptime!]!
 }
+
+type PlayEvent {
+  userId: String!
+  city: String!
+  country: String!
+  region: String!
+  timestamp: String!
+}
+
+type Subscription {
+  playsByTrack(id: String!): PlayEvent!
+}

--- a/pkg/core/pubsub/pubsub.go
+++ b/pkg/core/pubsub/pubsub.go
@@ -1,15 +1,16 @@
-// A generic pubsub system built with go channels. Used to communicate different pieces of data across the app.
-// Latest block, stream txs, etc.
-package server
+package pubsub
 
 import (
 	"context"
 	"sync"
+
+	"github.com/AudiusProject/audiusd/pkg/core/gen/core_proto"
 )
 
 // subscribes by tx hash, pubsub completes once tx
 // is committed
 type TransactionHashPubsub = Pubsub[struct{}]
+type PlaysPubsub = Pubsub[*core_proto.TrackPlay]
 
 type Pubsub[Message any] struct {
 	subscribers map[string]map[chan Message]struct{} // Map of topic to channels

--- a/pkg/core/server/http.go
+++ b/pkg/core/server/http.go
@@ -37,7 +37,7 @@ func (s *Server) startEchoServer() error {
 		s.logger.Errorf("could not register protocol handler server: %v", err)
 	}
 
-	gqlResolver := gql.NewGraphQLServer(s.config, s.logger, s.db)
+	gqlResolver := gql.NewGraphQLServer(s.config, s.logger, s.db, s.playsPubsub)
 	srv := handler.New(core_gql.NewExecutableSchema(core_gql.Config{Resolvers: gqlResolver}))
 	srv.Use(extension.Introspection{})
 	queryHandler := func(c echo.Context) error {

--- a/pkg/core/server/subscriber.go
+++ b/pkg/core/server/subscriber.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/AudiusProject/audiusd/pkg/core/gen/core_proto"
+	"github.com/cometbft/cometbft/types"
+	"google.golang.org/protobuf/proto"
+)
+
+func (s *Server) startSubscriber() error {
+	<-s.awaitRpcReady
+
+	node := s.node
+	eb := node.EventBus()
+
+	if eb == nil {
+		return errors.New("event bus not ready")
+	}
+
+	subscriberID := "block-cache-subscriber"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	query := types.EventQueryNewBlock
+	subscription, err := eb.Subscribe(ctx, subscriberID, query)
+	if err != nil {
+		return fmt.Errorf("failed to subscribe to NewBlock events: %v", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.logger.Info("Stopping block event subscription")
+			return nil
+		case msg := <-subscription.Out():
+			blockEvent := msg.Data().(types.EventDataNewBlock)
+
+			s.updateLatestBlock(&blockEvent)
+			s.broadcastPubsubEvents(&blockEvent)
+
+		case err := <-subscription.Canceled():
+			s.logger.Errorf("Subscription cancelled: %v", err)
+			return nil
+		}
+	}
+}
+
+func (s *Server) updateLatestBlock(blockEvent *types.EventDataNewBlock) {
+	blockHeight := blockEvent.Block.Height
+	atomic.StoreInt64(&s.cache.currentHeight, blockHeight)
+}
+
+func (s *Server) broadcastPubsubEvents(blockEvent *types.EventDataNewBlock) {
+	ctx := context.Background()
+
+	height := blockEvent.Block.Height
+	txs, err := s.db.GetBlockTransactions(ctx, height)
+	if err != nil {
+		s.logger.Errorf("block %d not available for pubsub broadcast: %v", height, err)
+		return
+	}
+
+	for _, tx := range txs {
+		txbytes := tx.Transaction
+		var tx core_proto.SignedTransaction
+		err := proto.Unmarshal(txbytes, &tx)
+		if err != nil {
+			continue
+		}
+
+		if plays := tx.GetPlays(); plays != nil {
+			for _, play := range plays.GetPlays() {
+				s.playsPubsub.Publish(ctx, play.TrackId, play)
+			}
+		}
+	}
+}


### PR DESCRIPTION
- adds a pubsub lib to be used with the server and gql
- adds a new subscriber.go task that just fires off side effects when new blocks come through

- this works when going directly to the 26659 server but there's something with the audiusd and nginx reverse proxies that make it not work. 0.0.0.0:26659/core/graphiql with a subscription works but the others just close immediately. still figuring out how to do that right.