### PR TITLE
sort responses for grpc endpoint

### DIFF
--- a/pkg/core/server/grpc.go
+++ b/pkg/core/server/grpc.go
@@ -182,7 +182,6 @@ func (s *Server) GetBlock(ctx context.Context, req *core_proto.GetBlockRequest) 
 		return nil, err
 	}
 
-	txs := []*core_proto.SignedTransaction{}
 	tx_responses := []*core_proto.TransactionResponse{}
 	for _, tx := range blockTxs {
 		var transaction core_proto.SignedTransaction
@@ -190,7 +189,6 @@ func (s *Server) GetBlock(ctx context.Context, req *core_proto.GetBlockRequest) 
 		if err != nil {
 			return nil, err
 		}
-		txs = append(txs, &transaction)
 		res := &core_proto.TransactionResponse{
 			Txhash:      transaction.TxHash(),
 			Transaction: &transaction,
@@ -203,10 +201,10 @@ func (s *Server) GetBlock(ctx context.Context, req *core_proto.GetBlockRequest) 
 		Chainid:              s.config.GenesisFile.ChainID,
 		Proposer:             block.Proposer,
 		Height:               block.Height,
-		Transactions:         txs,
+		Transactions:         []*core_proto.SignedTransaction{},
 		CurrentHeight:        currentHeight,
 		Timestamp:            timestamppb.New(block.CreatedAt.Time),
-		TransactionResponses: tx_responses,
+		TransactionResponses: sortTransactionResponse(tx_responses),
 	}
 
 	return res, nil

--- a/pkg/core/server/tx.go
+++ b/pkg/core/server/tx.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"hash/fnv"
+	"sort"
+	"strings"
+
+	"github.com/AudiusProject/audiusd/pkg/core/gen/core_proto"
+)
+
+// stringToUint32 generates a deterministic uint32 hash from a string
+func stringToUint32(s string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(s))
+	return h.Sum32()
+}
+
+// isStringGreater compares two strings based on their deterministic integer values
+func isStringGreater(a, b string) bool {
+	return stringToUint32(a) > stringToUint32(b)
+}
+
+// isCreateAction checks if the manage entity action is a "Create"
+func isCreateAction(action string) bool {
+	return strings.EqualFold(action, "Create") // Case-insensitive exact match
+}
+
+// getTransactionType categorizes the transaction
+func getTransactionType(tx *core_proto.SignedTransaction) string {
+	switch {
+	case tx.GetManageEntity() != nil:
+		return "manage"
+	case tx.GetPlays() != nil:
+		return "play"
+	default:
+		return "other"
+	}
+}
+
+// sortTransactionResponse sorts transactions with a defined priority
+func sortTransactionResponse(txs []*core_proto.TransactionResponse) []*core_proto.TransactionResponse {
+	sort.SliceStable(txs, func(i, j int) bool {
+		one, two := txs[i].GetTransaction(), txs[j].GetTransaction()
+
+		oneType, twoType := getTransactionType(one), getTransactionType(two)
+
+		// Prioritize "manage" entities over "plays"
+		if oneType != twoType {
+			return oneType == "manage"
+		}
+
+		// If both are manage entities, prioritize "Create" actions
+		if oneType == "manage" && twoType == "manage" {
+			oneIsCreate := isCreateAction(one.GetManageEntity().Action)
+			twoIsCreate := isCreateAction(two.GetManageEntity().Action)
+
+			if oneIsCreate != twoIsCreate {
+				return oneIsCreate
+			}
+		}
+
+		// Fallback to deterministic signature comparison
+		return isStringGreater(one.GetSignature(), two.GetSignature())
+	})
+
+	return txs
+}


### PR DESCRIPTION
adds some ordering to the txs in the response, when creates and put after modifications it can break downstream indexers