### PR TITLE
Allow pg connections from outside container when on the same host

### DIFF
--- a/cmd/audiusd/entrypoint.sh
+++ b/cmd/audiusd/entrypoint.sh
@@ -69,6 +69,13 @@ setup_postgres() {
                 s|#logging_collector = on|logging_collector = off|" \
                 "$POSTGRES_DATA_DIR/postgresql.conf"
 
+        if [ "${AUDIUSD_PGALL:-false}" = "true" ]; then
+            # WARNING: use only with `-p "127.0.0.1:5432:5432"`
+            echo "WARNING: AUDIUSD_PGALL is set to true, this will allow all connections from any host"
+            echo "host all all 0.0.0.0/0 trust" >> "$POSTGRES_DATA_DIR/pg_hba.conf"
+            sed -i "s|#listen_addresses = 'localhost'|listen_addresses = '*'|" "$POSTGRES_DATA_DIR/postgresql.conf"
+        fi
+
         # Only set up database and user on fresh initialization
         echo "Setting up PostgreSQL user and database..."
         # Start PostgreSQL temporarily to create user and database


### PR DESCRIPTION
The case below will allow `my-go-app` to query the audiusd postgres. Useful for easy access to ETL data from localhost. 
Given the complexities of docker networking I couldn't make it work with a strict CIDR (still not clear as to why not). Hence gated this behind an env and will remain safe if ports bound as per below.

```
services:
  api:
    image: my-go-app
    depends_on:
      - audiusd
  audiusd:
    image: audius/audiusd:locals
    environment:
      - AUDIUSD_PGALL=true
      - AUDIUSD_ETL_ENABLED=true
    ports:
      - "127.0.0.1:5432:5432"
```