### PR TITLE
Make amount validation a max, not an exact check

### DIFF
--- a/pkg/core/rewards/routes.go
+++ b/pkg/core/rewards/routes.go
@@ -48,7 +48,7 @@ func (rs *RewardService) AttestReward(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, err.Error())
 	}
 
-	if amountUint != reward.Amount {
+	if amountUint > reward.Amount {
 		return c.JSON(http.StatusBadRequest, "amount does not match reward amount")
 	}
 


### PR DESCRIPTION
Right now, in the attestation logic, the `amount` is verified against the config exactly. This breaks for any old challenges that don’t match the new amount (eg. rewards went up from 1 to 5 for audio match, or trending from 100 to 1000)

My options:
- remove amount checking from the attest endpoint
- consume the new amounts (old challenges become upgraded to new amounts)
- change the check to ensure a max, not an exact number

I chose the last one