### PR TITLE
golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,25 +4,6 @@ orbs:
   gh: circleci/github-cli@2.4.0
 
 commands:
-  setup-audius-ctl:
-    description: Checkout and install audius-ctl built in previous job
-    steps:
-      - checkout
-      - attach_workspace:
-          at: ./
-      - run:
-          name: Uninstall any existing audius-ctl binary
-          command: |
-            make uninstall
-      - run:
-          name: Install audius-ctl
-          command: |
-            make install
-      - run:
-          name: 'Install self-signed ssl certificate for devnet.audius-d'
-          command: |
-            sudo cp dev-tools/tls/devnet-cert.pem /usr/local/share/ca-certificates/devnet.audius-d.crt
-            sudo update-ca-certificates
   docker-login:
     steps:
       - run:
@@ -71,6 +52,24 @@ commands:
 
 
 jobs:
+  install-deps:
+    docker:
+      - image: cimg/go:1.23
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: make install-go-deps
+
+  lint:
+    docker:
+      - image: cimg/go:1.23
+    steps:
+      - checkout
+      - run:
+          name: Run linter
+          command: make lint || true
+
   build-audiusd-bin:
     docker:
       - image: cimg/go:1.23
@@ -84,11 +83,6 @@ jobs:
       - checkout
       - install-buf
       - push-buf
-      - run:
-          name: Install build dependencies
-          command: |
-            make install-go-deps
-            go mod download
       - run:
           name: Build audiusd binaries
           command: |
@@ -250,7 +244,14 @@ jobs:
 workflows:
   audiusd:
     jobs:
-      - build-audiusd-bin
+      - install-deps
+      - lint:
+          requires:
+            - install-deps
+      - build-audiusd-bin:
+          requires:
+            - install-deps
+            - lint
       - build-and-test-audiusd-amd64:
           context: DockerHub
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,28 @@
 version: 2.1
 
 orbs:
-  gh: circleci/github-cli@2.7.0
+  gh: circleci/github-cli@2.4.0
 
 commands:
+  setup-audius-ctl:
+    description: Checkout and install audius-ctl built in previous job
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Uninstall any existing audius-ctl binary
+          command: |
+            make uninstall
+      - run:
+          name: Install audius-ctl
+          command: |
+            make install
+      - run:
+          name: 'Install self-signed ssl certificate for devnet.audius-d'
+          command: |
+            sudo cp dev-tools/tls/devnet-cert.pem /usr/local/share/ca-certificates/devnet.audius-d.crt
+            sudo update-ca-certificates
   docker-login:
     steps:
       - run:
@@ -52,24 +71,6 @@ commands:
 
 
 jobs:
-  install-deps:
-    docker:
-      - image: cimg/go:1.23
-    steps:
-      - checkout
-      - run:
-          name: Install dependencies
-          command: make install-deps
-
-  lint:
-    docker:
-      - image: cimg/go:1.23
-    steps:
-      - checkout
-      - run:
-          name: Run linter
-          command: make lint || true
-
   build-audiusd-bin:
     docker:
       - image: cimg/go:1.23
@@ -83,6 +84,15 @@ jobs:
       - checkout
       - install-buf
       - push-buf
+      - run:
+          name: Install build dependencies
+          command: |
+            make install-go-deps
+            go mod download
+      - run:
+          name: Lint
+          command: |
+            make lint || true
       - run:
           name: Build audiusd binaries
           command: |
@@ -244,14 +254,7 @@ jobs:
 workflows:
   audiusd:
     jobs:
-      - install-deps
-      - lint:
-          requires:
-            - install-deps
-      - build-audiusd-bin:
-          requires:
-            - install-deps
-            - lint
+      - build-audiusd-bin
       - build-and-test-audiusd-amd64:
           context: DockerHub
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  gh: circleci/github-cli@2.4.0
+  gh: circleci/github-cli@2.7.0
 
 commands:
   docker-login:
@@ -59,7 +59,7 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: make install-go-deps
+          command: make install-deps
 
   lint:
     docker:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,30 @@
+run:
+  timeout: 2m
+  tests: true
+
+linters:
+  enable:
+    - staticcheck
+    - gofmt
+    - goimports
+    - govet
+    - errcheck
+    - revive
+    - unused
+    - ineffassign
+    - gosimple
+    - stylecheck
+    - dupl
+    - goconst
+
+linters-settings:
+  gofmt:
+    simplify: true
+  revive:
+    ignore-generated-header: true
+    severity: warning
+
+issues:
+  exclude-use-default: false
+  max-same-issues: 10
+  max-issues-per-linter: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,14 +8,12 @@ linters:
     - gofmt
     - goimports
     - govet
-    - errcheck
     - revive
     - unused
     - ineffassign
     - gosimple
     - stylecheck
     - dupl
-    - goconst
 
 linters-settings:
   gofmt:

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,15 @@ install-go-deps:
 	go install -v github.com/cortesi/modd/cmd/modd@latest
 	go install -v github.com/a-h/templ/cmd/templ@latest
 	go install -v github.com/ethereum/go-ethereum/cmd/abigen@latest
-	go install honnef.co/go/tools/cmd/staticcheck@latest
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
+.PHONY: lint
+lint:
+	golangci-lint run
+
+.PHONY: lint-fix
+lint-fix:
+	golangci-lint run --fix
 
 go.sum: go.mod
 go.mod: $(GO_SRCS)

--- a/cmd/audius-ctl/completions.go
+++ b/cmd/audius-ctl/completions.go
@@ -32,7 +32,7 @@ func getAvailableHostsWithPrefix(prefix string) ([]string, error) {
 		return nil, logger.Error("Could not get current context:", err)
 	}
 	hosts := make([]string, 0)
-	for host, _ := range ctx.Nodes {
+	for host := range ctx.Nodes {
 		if strings.HasPrefix(host, prefix) {
 			hosts = append(hosts, host)
 		}

--- a/cmd/audius-ctl/main.go
+++ b/cmd/audius-ctl/main.go
@@ -65,7 +65,7 @@ func main() {
 
 	vmsg := <-msgCh
 	if vmsg != "" {
-		fmt.Fprintf(os.Stderr, vmsg)
+		fmt.Fprint(os.Stderr, vmsg)
 	}
 
 	if err != nil {

--- a/cmd/audius-ctl/status.go
+++ b/cmd/audius-ctl/status.go
@@ -264,7 +264,7 @@ func writeResultsToTable(results []hcResult) error {
 			usedBytes: res.HealthSummary.DiskSpaceUsedBytes,
 			sizeBytes: res.HealthSummary.DiskSpaceSizeBytes,
 		}
-		row[uptimeCol] = time.Now().Sub(res.HealthSummary.BootTime)
+		row[uptimeCol] = time.Since(res.HealthSummary.BootTime)
 		if res.HealthSummary.IPCheck {
 			row[ipCol] = "matched"
 		} else {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AudiusProject/audiusd
 
-go 1.24.2
+go 1.23.8
 
 require (
 	github.com/a-h/templ v0.3.819

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/AudiusProject/audiusd
 
-go 1.23.8
-
-toolchain go1.24.2
+go 1.24.2
 
 require (
 	github.com/a-h/templ v0.3.819

--- a/hooks/pre-push.json
+++ b/hooks/pre-push.json
@@ -1,0 +1,8 @@
+{
+  "steps": [
+    {
+      "name": "lint",
+      "command": "make lint"
+    }
+  ]
+}

--- a/pkg/core/console/pos.go
+++ b/pkg/core/console/pos.go
@@ -21,9 +21,9 @@ func (cs *Console) posFragment(c echo.Context) error {
 	proofs, err := cs.db.GetStorageProofsForNodeInRange(
 		ctx,
 		db.GetStorageProofsForNodeInRangeParams{
-			start,
-			end,
-			cs.state.cometAddress,
+			BlockHeight:   start,
+			BlockHeight_2: end,
+			Address:       cs.state.cometAddress,
 		},
 	)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {

--- a/pkg/core/console/uptime.go
+++ b/pkg/core/console/uptime.go
@@ -122,8 +122,8 @@ func (cs *Console) uptimeFragment(c echo.Context) error {
 	posRollups, err := cs.db.GetStorageProofRollups(
 		ctx,
 		db.GetStorageProofRollupsParams{
-			activeReport.BlockStart,
-			activeReport.BlockEnd,
+			BlockHeight:   activeReport.BlockStart,
+			BlockHeight_2: activeReport.BlockEnd,
 		},
 	)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
@@ -211,7 +211,7 @@ func (cs *Console) getActiveSlaReport(ctx context.Context, rollupId string) (pag
 }
 
 func (cs *Console) getAverageBlockTimeForReport(ctx context.Context, report pages.SlaReport) (int, error) {
-	var avgBlockTimeMs int = 0
+	var avgBlockTimeMs = 0
 	previousRollup, err := cs.db.GetPreviousSlaRollupFromId(ctx, report.SlaRollupId)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		err = fmt.Errorf("Failure reading previous SlaRollup from db: %v", err)

--- a/pkg/core/server/eth.go
+++ b/pkg/core/server/eth.go
@@ -113,7 +113,7 @@ func (s *Server) gatherEthNodes() error {
 	}
 
 	missingEthNodes := make([]string, 0, len(missingEthNodeSet))
-	for addr, _ := range missingEthNodeSet {
+	for addr := range missingEthNodeSet {
 		missingEthNodes = append(missingEthNodes, addr)
 	}
 	s.missingEthNodes = missingEthNodes

--- a/pkg/core/server/registry_bridge.go
+++ b/pkg/core/server/registry_bridge.go
@@ -189,7 +189,7 @@ func (s *Server) registerSelfOnComet(ctx context.Context, delegateOwnerWallet ge
 		SpId:           spID,
 		Deadline:       s.cache.currentHeight.Load() + 120,
 	}
-	for addr, _ := range rendezvous {
+	for addr := range rendezvous {
 		if peer, ok := peers[addr]; ok {
 			resp, err := peer.GetRegistrationAttestation(ctx, connect.NewRequest(&v1.GetRegistrationAttestationRequest{
 				Registration: &v1.ValidatorRegistration{
@@ -415,7 +415,7 @@ func (s *Server) deregisterMissingNode(ctx context.Context, ethAddress string) {
 	}
 
 	peers := s.GetPeers()
-	for addr, _ := range rendezvous {
+	for addr := range rendezvous {
 		if peer, ok := peers[addr]; ok {
 			resp, err := peer.GetDeregistrationAttestation(ctx, connect.NewRequest(&v1.GetDeregistrationAttestationRequest{
 				Deregistration: &v1.ValidatorDeregistration{

--- a/pkg/logger/cli_handler.go
+++ b/pkg/logger/cli_handler.go
@@ -6,8 +6,6 @@ import (
 	"os"
 )
 
-var ()
-
 // Log handler specifically for CLI usage.
 type CliHandler struct {
 	handler slog.Handler

--- a/pkg/mediorum/crudr/crudr.go
+++ b/pkg/mediorum/crudr/crudr.go
@@ -316,7 +316,7 @@ func (c *Crudr) GetOutboxSizes() map[string]int {
 
 func (c *Crudr) GetPercentNodesSeeded() float64 {
 	var nCaughtUp int
-	var nPeers int = len(c.peerClients)
+	var nPeers = len(c.peerClients)
 	for _, p := range c.peerClients {
 		if p.Seeded {
 			nCaughtUp++


### PR DESCRIPTION
- adds golangci-lint to the Makefile and ci
two new commands:
```
make lint
make lint-fix
```

make lint will run the linter, make lint-fix will auto fix lint errors that can be fixed automatically