### PR TITLE
add "if not exists" check to release migrations

### DIFF
--- a/pkg/core/db/sql/migrations/00018_release_metadata.sql
+++ b/pkg/core/db/sql/migrations/00018_release_metadata.sql
@@ -4,7 +4,7 @@ create table if not exists track_releases(
   track_id text not null unique
 );
 
-create index idx_track_releases_track_id on track_releases(track_id);
+create index if not exists idx_track_releases_track_id on track_releases(track_id);
 
 create table if not exists sound_recordings(
   id serial primary key,
@@ -14,7 +14,7 @@ create table if not exists sound_recordings(
   encoding_details text
 );
 
-create index idx_sound_recordings_track_id on sound_recordings(track_id);
+create index if not exists idx_sound_recordings_track_id on sound_recordings(track_id);
 
 create table if not exists access_keys(
   id serial primary key,
@@ -22,7 +22,7 @@ create table if not exists access_keys(
   pub_key text not null
 );
 
-create index idx_access_keys_track_id on access_keys(track_id);
+create index if not exists idx_access_keys_track_id on access_keys(track_id);
 
 create table if not exists management_keys(
   id serial primary key,
@@ -30,4 +30,4 @@ create table if not exists management_keys(
   pub_key text not null
 );
 
-create index idx_management_keys_track_id on management_keys(track_id);
+create index if not exists idx_management_keys_track_id on management_keys(track_id);


### PR DESCRIPTION
these were missing the idempotency check and were causing stage dn1 core to not stand up