### PR TITLE
endl/entrypoint

### DIFF
--- a/cmd/audiusd/entrypoint.sh
+++ b/cmd/audiusd/entrypoint.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-# Set default network to prod if not specified
 NETWORK="${NETWORK:-prod}"
 ENV_FILE="/env/${NETWORK}.env"
-OVERRIDE_ENV_FILE="/env/override.env"
 
 if [ ! -f "$ENV_FILE" ]; then
     echo "Error: Network environment file not found at $ENV_FILE"
@@ -28,29 +26,28 @@ source_env_file() {
 }
 
 source_env_file "$ENV_FILE"
-source_env_file "$OVERRIDE_ENV_FILE"
 
 if [ -n "$creatorNodeEndpoint" ]; then
     POSTGRES_DB="audius_creator_node"
-    POSTGRES_DATA_DIR=${POSTGRES_DATA_DIR:-/data/creator-node-db-15}
+    POSTGRES_DATA_DIR="${POSTGRES_DATA_DIR:-/data/creator-node-db-15}"
 elif [ -n "$audius_discprov_url" ]; then
     POSTGRES_DB="audius_discovery"
-    POSTGRES_DATA_DIR=${POSTGRES_DATA_DIR:-/data/discovery-provider-db}
+    POSTGRES_DATA_DIR="${POSTGRES_DATA_DIR:-/data/discovery-provider-db}"
 else
-    POSTGRES_DB="audiusd"
+    POSTGRES_DB="${POSTGRES_DB:-audiusd}"
+    POSTGRES_DATA_DIR="${POSTGRES_DATA_DIR:-/data/postgres}"
 fi
 
-POSTGRES_USER="postgres"
-POSTGRES_PASSWORD="postgres"
-POSTGRES_DATA_DIR=${POSTGRES_DATA_DIR:-/data/postgres}
-export dbUrl="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}?sslmode=disable"
-export uptimeDataDir=${uptimeDataDir:-/data/bolt}
-export audius_core_root_dir=${audius_core_root_dir:-/data/bolt}
+POSTGRES_USER="${POSTGRES_USER:-postgres}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-postgres}"
+dbUrl="${dbUrl:-postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}?sslmode=disable}"
+uptimeDataDir="${uptimeDataDir:-/data/bolt}"
+audius_core_root_dir="${audius_core_root_dir:-/data/bolt}"
+
+export POSTGRES_DB POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DATA_DIR dbUrl uptimeDataDir audius_core_root_dir
 
 setup_postgres() {
     PG_BIN="/usr/lib/postgresql/15/bin"
-    
-    # Ensure directories exist with correct permissions
     mkdir -p /data
     mkdir -p "$POSTGRES_DATA_DIR"
     chown -R postgres:postgres /data
@@ -90,12 +87,8 @@ setup_postgres() {
         # Stop PostgreSQL to restart it properly
         su - postgres -c "$PG_BIN/pg_ctl -D $POSTGRES_DATA_DIR stop"
     fi
-
-    # Always start PostgreSQL
     echo "Starting PostgreSQL service..."
     su - postgres -c "$PG_BIN/pg_ctl -D $POSTGRES_DATA_DIR start"
-
-    # Wait for PostgreSQL to be ready
     until su - postgres -c "$PG_BIN/pg_isready -q"; do
         echo "Waiting for PostgreSQL to start..."
         sleep 2

--- a/docs/validators.md
+++ b/docs/validators.md
@@ -30,10 +30,10 @@ EOF
 docker run -d \
   --name audiusd-cn1.operator.xyz \
   --restart unless-stopped \
+  --env-file /home/ubuntu/override.env \
   -v /var/k8s/creator-node-db-15:/data/creator-node-db-15 \
   -v /var/k8s/bolt:/data/bolt \
   -v /var/k8s/mediorum:/tmp/mediorum \
-  -v /home/ubuntu/override.env:/env/override.env \
   -p 80:80 \
   -p 443:443 \
   -p 26656:26656 \
@@ -55,8 +55,8 @@ EOF
 docker run -d \
   --name audiusd-dn1.operator.xyz \
   --restart unless-stopped \
+  --env-file /home/ubuntu/override.env \
   -v /var/k8s:/data \
-  -v /home/ubuntu/override.env:/env/override.env \
   -p 80:80 \
   -p 443:443 \
   -p 26656:26656 \
@@ -133,7 +133,7 @@ if $FORCE_UPDATE || ! echo "$PULL_STATUS" | grep -q 'Status: Image is up to date
     docker run -d \
         --name audiusd-${AUDIUSD_HOSTNAME} \
         --restart unless-stopped \
-        -v ${OVERRIDE_ENV_PATH}:/env/override.env \
+        --env-file ${OVERRIDE_ENV_PATH} \
         -v /var/k8s:/data \
         -p 80:80 \
         -p 443:443 \


### PR DESCRIPTION
# override.env should **not** be mounted as file.

## fixes

consistency between `docker run` and  audius-ctl / audius-docker-compose setups.

## changes

the audiusd container will now will expect the override.env to be supplied via the `--env-file` directive and not mounted as a file with `-v`. 

see the README [diff](https://github.com/AudiusProject/audiusd/pull/126/files#diff-3d33287df20fae3f2c8d0b80edc57ecd8a25453c1716348251d08104b34a4fa3) to confirm if this affects your setup.
if you are using audius-ctl / audius-docker-compose, this should not affect you.