### PR TITLE
Version 0.7.101

### DIFF
--- a/pkg/version/.version.json
+++ b/pkg/version/.version.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.7.100",
+  "version": "0.7.101",
   "service": "content-node"
 }


### PR DESCRIPTION
bumps version in .version.json, taking out to all envs once merged