### PR TITLE
fix SS error log

### DIFF
--- a/pkg/core/server/state_sync.go
+++ b/pkg/core/server/state_sync.go
@@ -345,6 +345,10 @@ func (s *Server) pruneSnapshots(logger *common.Logger) error {
 }
 
 func (s *Server) getStoredSnapshots() ([]v1.Snapshot, error) {
+	if !s.config.StateSync.ServeSnapshots {
+		return []v1.Snapshot{}, nil
+	}
+
 	snapshotDir := getSnapshotDir(s.config.RootDir, s.config.GenesisFile.ChainID)
 
 	dirs, err := os.ReadDir(snapshotDir)


### PR DESCRIPTION
if state sync is not enabled then just return an empty array of snapshots
this will avoid the spammy error when it's disabled:
```
{"time":"2025-07-02T03:06:32.775455549Z","level":"ERROR","msg":"error caching snapshots: error getting stored snapshots: error reading snapshot directory: open tmp/content1Home/snapshots_audius-devnet: no such file or directory","service":"server"}
```