### PR TITLE
use central eth rpc endpoint by default

### DIFF
--- a/cmd/audiusd/env/prod.env
+++ b/cmd/audiusd/env/prod.env
@@ -5,8 +5,8 @@ uptimeDataDir=/bolt
 MEDIORUM_ENV=prod
 audius_discprov_env=prod
 
-ethProviderUrl=https://eth-mainnet.g.alchemy.com/v2/4hFRA61i6OFXz2UmkyFsSvgXBQBBOGgW
-audius_web3_eth_provider_url=https://eth-mainnet.g.alchemy.com/v2/jxDQvtprZBSxiGW1KTtZR2_O1ZZLCoC3
+ethProviderUrl=https://eth-validator.audius.co
+audius_web3_eth_provider_url=https://eth-validator.audius.co
 ethRegistryAddress=0xd976d3b4f4e22a238c1A736b6612D22f17b6f64C
 ethTokenAddress=0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998
 

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -47,7 +47,7 @@ const (
 	StageAcdcAddress = "0x1Cd8a543596D499B9b6E7a6eC15ECd2B7857Fd64"
 	DevAcdcAddress   = "0x254dffcd3277C0b1660F6d42EFbB754edaBAbC2B"
 
-	ProdEthRpc  = "https://eth.audius.co"
+	ProdEthRpc  = "https://eth-validator.audius.co"
 	StageEthRpc = "https://eth-validator.staging.audius.co"
 	DevEthRpc   = "http://eth-ganache:8545"
 

--- a/pkg/eth/contracts/contracts_test.go
+++ b/pkg/eth/contracts/contracts_test.go
@@ -15,7 +15,7 @@ func TestGetAllRegisteredNodes(t *testing.T) {
 
 	ctx := context.Background()
 
-	ethrpc, err := ethclient.Dial("https://eth.audius.co")
+	ethrpc, err := ethclient.Dial("https://eth-validator.audius.co")
 	require.Nil(t, err)
 	defer ethrpc.Close()
 


### PR DESCRIPTION
As title.

Tested by temporarily unskipping contracts_test.go under pkg/eth/contracts/, and by also ensuring a websocket protocol connection could be established.