### PR TITLE
fix ordering of state sync initial data

### DIFF
--- a/pkg/core/server/data_companion.go
+++ b/pkg/core/server/data_companion.go
@@ -16,6 +16,9 @@ func (s *Server) startDataCompanion(ctx context.Context) error {
 
 	s.logger.Info("starting data companion")
 
+	storingSnapshots := s.config.StateSync.ServeSnapshots
+	snapshotInterval := s.config.StateSync.BlockInterval
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/pkg/core/server/data_companion.go
+++ b/pkg/core/server/data_companion.go
@@ -45,6 +45,17 @@ func (s *Server) startDataCompanion(ctx context.Context) error {
 				continue
 			}
 
+			// Ensure we keep enough blocks for snapshots
+			if storingSnapshots && snapshotInterval > 0 {
+				// Add a buffer equal to one full snapshot interval to ensure we
+				// always retain enough historical blocks to fully serve the
+				// most recent snapshot without risk of pruning too far.
+				wantMin := blockRetainHeight.App + uint64(snapshotInterval)
+				if blockRetainHeight.App < wantMin {
+					blockRetainHeight.App = wantMin
+				}
+			}
+
 			if err := conn.SetBlockRetainHeight(ctx, blockRetainHeight.App); err != nil {
 				s.logger.Errorf("dc could not set block retain height: %v", err)
 			}

--- a/pkg/core/server/state_sync.go
+++ b/pkg/core/server/state_sync.go
@@ -614,18 +614,20 @@ func (s *Server) cacheSnapshots() error {
 		return fmt.Errorf("error getting stored snapshots: %w", err)
 	}
 
-	for _, snapshot := range snapshots {
-		upsertCache(s.cache.snapshotInfo, SnapshotInfoKey, func(snapshotInfo *corev1.GetStatusResponse_SnapshotInfo) *corev1.GetStatusResponse_SnapshotInfo {
-			snapshotInfo.Enabled = s.config.StateSync.ServeSnapshots
-			snapshotInfo.Snapshots = append(snapshotInfo.Snapshots, &corev1.SnapshotMetadata{
+	return upsertCache(s.cache.snapshotInfo, SnapshotInfoKey, func(snapshotInfo *corev1.GetStatusResponse_SnapshotInfo) *corev1.GetStatusResponse_SnapshotInfo {
+		snapshotInfo.Enabled = s.config.StateSync.ServeSnapshots
+
+		newSnapshots := make([]*corev1.SnapshotMetadata, 0, len(snapshots))
+		for _, snapshot := range snapshots {
+			newSnapshots = append(newSnapshots, &corev1.SnapshotMetadata{
 				Height:     int64(snapshot.Height),
 				Hash:       hex.EncodeToString(snapshot.Hash),
 				ChunkCount: int64(snapshot.Chunks),
 				ChainId:    s.config.GenesisFile.ChainID,
 			})
-			return snapshotInfo
-		})
-	}
+		}
 
-	return nil
+		snapshotInfo.Snapshots = newSnapshots
+		return snapshotInfo
+	})
 }


### PR DESCRIPTION
In the initial implementation you needed the trusted block to be present on the node where the snapshot is. This doesn't work in cases like CN1 where it has snapshots but also prunes blocks. The node can still get the trusted block from CN2 so this new implementation should allow the snapshot to be picked from CN1 and the trusted block from CN2. 

Will test on prod explorer.