### PR TITLE
smart peering

### DIFF
--- a/pkg/core/server/aliases.go
+++ b/pkg/core/server/aliases.go
@@ -1,0 +1,11 @@
+// simple type aliases that make readability, imports, and auto complete easier
+package server
+
+import (
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+)
+
+type EthAddress = string
+type CometBFTAddress = string
+
+type CometBFTRPC = rpchttp.HTTP

--- a/pkg/core/server/peers_p2p.go
+++ b/pkg/core/server/peers_p2p.go
@@ -1,0 +1,168 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"connectrpc.com/connect"
+	v1 "github.com/AudiusProject/audiusd/pkg/api/core/v1"
+	"github.com/AudiusProject/audiusd/pkg/api/core/v1/v1connect"
+	"github.com/AudiusProject/audiusd/pkg/safemap"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+)
+
+func (s *Server) startP2PPeers(ctx context.Context) error {
+	<-s.awaitRpcReady
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := s.refreshP2PPeers(ctx); err != nil {
+				s.logger.Errorf("error connecting to cometbft rpc peers: %v", err)
+			}
+		case <-ctx.Done():
+			// shut down rpc clients
+			return ctx.Err()
+		}
+	}
+}
+
+func (s *Server) refreshP2PPeers(ctx context.Context) error {
+	// get existing set of connected peers by nodeid (lowercase comet key)
+	nodeInfo, err := s.rpc.NetInfo(ctx)
+	if err != nil {
+		return fmt.Errorf("cannot get self netinfo: %v", err)
+	}
+
+	peers := nodeInfo.Peers
+	existingPeers := safemap.New[string, struct{}]()
+
+	for _, peer := range peers {
+		existingPeers.Set(string(peer.NodeInfo.DefaultNodeID), struct{}{})
+	}
+
+	// collect nodeid -> ip map from cometrpc peers
+	peerConnections := safemap.New[string, struct{}]()
+
+	rpcClients := s.cometRPCPeers.Values()
+	var wg sync.WaitGroup
+	wg.Add(len(rpcClients))
+
+	for _, rpc := range rpcClients {
+		go func(rpc *CometBFTRPC) {
+			defer wg.Done()
+			remoteNetInfo, err := rpc.NetInfo(ctx)
+			if err != nil {
+				return
+			}
+
+			remotePeers := remoteNetInfo.Peers
+			for _, peer := range remotePeers {
+				nodeid := peer.NodeInfo.DefaultNodeID
+				alreadyPeered := existingPeers.Has(string(nodeid))
+				if alreadyPeered {
+					continue
+				}
+				ip := peer.RemoteIP
+				address := net.JoinHostPort(ip, "26656")
+				conn, err := net.DialTimeout("tcp", address, 3*time.Second)
+				if err != nil {
+					// TODO: report 26656 status to core status endpoint
+					continue
+				}
+				_ = conn.Close()
+
+				connectionStr := fmt.Sprintf("%s@%s:26656", nodeid, peer.RemoteIP)
+				peerConnections.Set(connectionStr, struct{}{})
+			}
+		}(rpc)
+	}
+
+	wg.Wait()
+
+	// connect to ones available that aren't in existing peer set and have port open
+	dialPeers := []string{}
+	dialPeers = append(dialPeers, peerConnections.Keys()...)
+
+	if len(dialPeers) == 0 {
+		return nil
+	}
+
+	result, err := s.rpc.DialPeers(ctx, dialPeers, true, false, false)
+	if err != nil {
+		return err
+	}
+
+	s.logger.Infof("dialed peers: %s", result.Log)
+
+	return nil
+}
+
+// reads the existing connectrpc peers in the state and retains
+// cometbft rpc clients for each node as well
+func (s *Server) startCometRPCPeers(ctx context.Context) error {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := s.refreshCometBFTRPCPeers(ctx); err != nil {
+				s.logger.Errorf("error connecting to cometbft rpc peers: %v", err)
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (s *Server) refreshCometBFTRPCPeers(ctx context.Context) error {
+	// gather existing connectrpc peers
+	peers := s.GetPeers()
+
+	// already all peered up
+	if len(peers) == s.cometRPCPeers.Len() {
+		return nil
+	}
+
+	// iterate through connectrpc peers and
+	// if cometbft rpc doesn't exist, create and connect
+	var wg sync.WaitGroup
+	wg.Add(len(peers))
+
+	for peerEthAddr, peer := range peers {
+		go func(peerEthAddr EthAddress, peer v1connect.CoreServiceClient) {
+			defer wg.Done()
+
+			// if we have a client we don't need to recreate
+			ok := s.cometRPCPeers.Has(peerEthAddr)
+			if ok {
+				return
+			}
+
+			status, err := peer.GetStatus(ctx, connect.NewRequest(&v1.GetStatusRequest{}))
+			if err != nil {
+				return
+			}
+
+			endpoint := status.Msg.NodeInfo.Endpoint
+
+			rpc, err := rpchttp.New(endpoint + "/core/crpc")
+			if err != nil {
+				return
+			}
+
+			s.cometRPCPeers.Set(peerEthAddr, rpc)
+
+		}(peerEthAddr, peer)
+	}
+
+	wg.Wait()
+
+	return nil
+}

--- a/pkg/core/server/peers_p2p.go
+++ b/pkg/core/server/peers_p2p.go
@@ -16,7 +16,7 @@ import (
 
 func (s *Server) startP2PPeers(ctx context.Context) error {
 	<-s.awaitRpcReady
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(10 * time.Minute)
 	defer ticker.Stop()
 
 	for {

--- a/pkg/core/server/server.go
+++ b/pkg/core/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/AudiusProject/audiusd/pkg/pos"
 	"github.com/AudiusProject/audiusd/pkg/pubsub"
 	"github.com/AudiusProject/audiusd/pkg/rewards"
+	"github.com/AudiusProject/audiusd/pkg/safemap"
 	cconfig "github.com/cometbft/cometbft/config"
 	nm "github.com/cometbft/cometbft/node"
 	"github.com/cometbft/cometbft/rpc/client/local"
@@ -48,8 +49,10 @@ type Server struct {
 	rpc   *local.Local
 	mempl *Mempool
 
-	peers   map[string]corev1connect.CoreServiceClient
+	peers   map[EthAddress]corev1connect.CoreServiceClient
 	peersMU sync.RWMutex
+
+	cometRPCPeers *safemap.SafeMap[EthAddress, *CometBFTRPC]
 
 	txPubsub *TransactionHashPubsub
 
@@ -94,12 +97,13 @@ func NewServer(lc *lifecycle.Lifecycle, config *config.Config, cconfig *cconfig.
 		pool:               pool,
 		mediorumPoSChannel: posChannel,
 
-		db:        db.New(pool),
-		mempl:     mempl,
-		peers:     make(map[string]corev1connect.CoreServiceClient),
-		txPubsub:  txPubsub,
-		cache:     NewCache(config),
-		abciState: NewABCIState(config.RetainHeight),
+		db:            db.New(pool),
+		mempl:         mempl,
+		peers:         make(map[string]corev1connect.CoreServiceClient),
+		cometRPCPeers: safemap.New[EthAddress, *CometBFTRPC](),
+		txPubsub:      txPubsub,
+		cache:         NewCache(config),
+		abciState:     NewABCIState(config.RetainHeight),
 
 		httpServer: httpServer,
 		grpcServer: grpcServer,
@@ -124,6 +128,8 @@ func (s *Server) Start() error {
 	s.lc.AddManagedRoutine("data companion", s.startDataCompanion)
 	s.lc.AddManagedRoutine("log sync", s.syncLogs)
 	s.lc.AddManagedRoutine("state sync", s.startStateSync)
+	s.lc.AddManagedRoutine("p2p peer manager", s.startP2PPeers)
+	s.lc.AddManagedRoutine("cometbft rpc manager", s.startCometRPCPeers)
 
 	s.z.Info("routines started")
 

--- a/pkg/safemap/safemap.go
+++ b/pkg/safemap/safemap.go
@@ -1,0 +1,138 @@
+// Package safemap provides a concurrency-safe generic map.
+package safemap
+
+import (
+	"maps"
+	"sync"
+)
+
+// SafeMap is a threadsafe map[K]V.
+type SafeMap[K comparable, V any] struct {
+	mu sync.RWMutex
+	m  map[K]V
+}
+
+// New returns an empty SafeMap.
+func New[K comparable, V any]() *SafeMap[K, V] {
+	return &SafeMap[K, V]{m: make(map[K]V)}
+}
+
+// NewFrom initializes the map from an existing map (copied).
+func NewFrom[K comparable, V any](src map[K]V) *SafeMap[K, V] {
+	cp := make(map[K]V, len(src))
+	for k, v := range src {
+		cp[k] = v
+	}
+	return &SafeMap[K, V]{m: cp}
+}
+
+func (s *SafeMap[K, V]) Get(key K) (V, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.m[key]
+	return v, ok
+}
+
+func (s *SafeMap[K, V]) Set(key K, value V) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.m == nil {
+		s.m = make(map[K]V)
+	}
+	s.m[key] = value
+}
+
+func (s *SafeMap[K, V]) Delete(key K) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, key)
+}
+
+func (s *SafeMap[K, V]) Has(key K) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.m[key]
+	return ok
+}
+
+func (s *SafeMap[K, V]) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.m)
+}
+
+func (s *SafeMap[K, V]) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m = make(map[K]V)
+}
+
+// Keys returns a snapshot of keys.
+func (s *SafeMap[K, V]) Keys() []K {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	keys := make([]K, 0, len(s.m))
+	for k := range s.m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// Values returns a snapshot of values.
+func (s *SafeMap[K, V]) Values() []V {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	vals := make([]V, 0, len(s.m))
+	for _, v := range s.m {
+		vals = append(vals, v)
+	}
+	return vals
+}
+
+// Range iterates over entries; stop early by returning false.
+func (s *SafeMap[K, V]) Range(fn func(K, V) bool) {
+	s.mu.RLock()
+	// Take a snapshot to keep lock duration bounded if fn is slow.
+	cp := make(map[K]V, len(s.m))
+	maps.Copy(cp, s.m)
+	s.mu.RUnlock()
+
+	for k, v := range cp {
+		if !fn(k, v) {
+			return
+		}
+	}
+}
+
+// LoadOrStore returns the existing value if present; otherwise stores and returns the given value.
+func (s *SafeMap[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.m == nil {
+		s.m = make(map[K]V)
+	}
+	if v, ok := s.m[key]; ok {
+		return v, true
+	}
+	s.m[key] = value
+	return value, false
+}
+
+// Compute atomically updates the value for key using fn.
+// If fn returns delete=true, the entry is removed.
+func (s *SafeMap[K, V]) Compute(key K, fn func(prev V, ok bool) (next V, delete bool)) (V, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prev, ok := s.m[key]
+	next, del := fn(prev, ok)
+	if del {
+		delete(s.m, key)
+		var zero V
+		return zero, false
+	}
+	if s.m == nil {
+		s.m = make(map[K]V)
+	}
+	s.m[key] = next
+	return next, true
+}

--- a/pkg/safemap/safemap_test.go
+++ b/pkg/safemap/safemap_test.go
@@ -1,0 +1,321 @@
+// safemap_test.go
+package safemap
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sync"
+	"testing"
+)
+
+func TestNewAndBasicOps(t *testing.T) {
+	m := New[string, int]()
+	if m == nil {
+		t.Fatal("New returned nil")
+	}
+	if got := m.Len(); got != 0 {
+		t.Fatalf("Len() = %d, want 0", got)
+	}
+
+	// Set/Get/Has
+	m.Set("a", 1)
+	if got, ok := m.Get("a"); !ok || got != 1 {
+		t.Fatalf("Get(a) = (%d,%v), want (1,true)", got, ok)
+	}
+	if !m.Has("a") {
+		t.Fatalf("Has(a) = false, want true")
+	}
+
+	// Len
+	if got := m.Len(); got != 1 {
+		t.Fatalf("Len() = %d, want 1", got)
+	}
+
+	// Delete
+	m.Delete("a")
+	if _, ok := m.Get("a"); ok {
+		t.Fatalf("Get(a).ok = true after delete, want false")
+	}
+	if got := m.Len(); got != 0 {
+		t.Fatalf("Len() = %d after delete, want 0", got)
+	}
+}
+
+func TestNewFromCopies(t *testing.T) {
+	src := map[string]int{"x": 1, "y": 2}
+	m := NewFrom(src)
+
+	// Mutate src; SafeMap must not see changes.
+	src["x"] = 100
+	src["z"] = 3
+
+	if got, _ := m.Get("x"); got != 1 {
+		t.Fatalf("copy isolation failed: Get(x) = %d, want 1", got)
+	}
+	if _, ok := m.Get("z"); ok {
+		t.Fatalf("copy isolation failed: z present in SafeMap")
+	}
+
+	// Verify Keys snapshot is complete.
+	keys := m.Keys()
+	slices.Sort(keys)
+	if want := []string{"x", "y"}; !slices.Equal(keys, want) {
+		t.Fatalf("Keys() = %v, want %v", keys, want)
+	}
+}
+
+func TestKeysValuesSnapshots(t *testing.T) {
+	m := New[int, string]()
+	m.Set(1, "a")
+	m.Set(2, "b")
+
+	keys := m.Keys()
+	vals := m.Values()
+
+	// Modify map after snapshot; slices must be independent.
+	m.Set(3, "c")
+	m.Delete(1)
+
+	if len(keys) != 2 || len(vals) != 2 {
+		t.Fatalf("snapshot length changed after mutations: keys=%d vals=%d", len(keys), len(vals))
+	}
+
+	// Check contents (order not guaranteed).
+	keySet := make(map[int]struct{}, len(keys))
+	for _, k := range keys {
+		keySet[k] = struct{}{}
+	}
+	if _, ok := keySet[1]; !ok {
+		t.Fatalf("Keys snapshot missing 1")
+	}
+	if _, ok := keySet[2]; !ok {
+		t.Fatalf("Keys snapshot missing 2")
+	}
+
+	valSet := make(map[string]struct{}, len(vals))
+	for _, v := range vals {
+		valSet[v] = struct{}{}
+	}
+	if _, ok := valSet["a"]; !ok || func() bool { _, ok := valSet["b"]; return ok }() == false {
+		t.Fatalf("Values snapshot missing entries: %v", vals)
+	}
+}
+
+func TestRangeSnapshotAndEarlyStop(t *testing.T) {
+	m := New[string, int]()
+	for i := range 10 {
+		m.Set(fmt.Sprint('a'+i), i)
+	}
+
+	// Early stop after first element.
+	count := 0
+	m.Range(func(k string, v int) bool {
+		count++
+		return false
+	})
+	if count != 1 {
+		t.Fatalf("Range early stop visited %d, want 1", count)
+	}
+
+	// Snapshot behavior: mutating during Range must not affect iteration.
+	seen := map[string]int{}
+	m.Range(func(k string, v int) bool {
+		seen[k] = v
+		if v == 0 {
+			// Mutate underlying map while iterating snapshot.
+			m.Delete(k)
+			m.Set("zz", 999)
+		}
+		return true
+	})
+
+	// We should have seen only the original 10 entries (in some order),
+	// not the newly added "zz", and still include the deleted key because snapshot.
+	if len(seen) != 10 {
+		t.Fatalf("Range snapshot size = %d, want 10", len(seen))
+	}
+	if _, ok := seen["zz"]; ok {
+		t.Fatalf("Range snapshot unexpectedly included mutation 'zz'")
+	}
+}
+
+func TestLoadOrStore(t *testing.T) {
+	m := New[string, int]()
+
+	// Store new
+	got, loaded := m.LoadOrStore("a", 1)
+	if got != 1 || loaded {
+		t.Fatalf("LoadOrStore new = (%d,%v), want (1,false)", got, loaded)
+	}
+
+	// Load existing
+	got, loaded = m.LoadOrStore("a", 2)
+	if got != 1 || !loaded {
+		t.Fatalf("LoadOrStore existing = (%d,%v), want (1,true)", got, loaded)
+	}
+
+	// Ensure value not replaced on load path
+	if v, _ := m.Get("a"); v != 1 {
+		t.Fatalf("value changed to %d, want 1", v)
+	}
+}
+
+func TestComputeSetAndDelete(t *testing.T) {
+	m := New[string, int]()
+
+	// Set using Compute when key absent.
+	next, ok := m.Compute("k", func(prev int, present bool) (int, bool) {
+		if present {
+			t.Fatalf("present unexpectedly true")
+		}
+		return 42, false // not delete
+	})
+	if !ok || next != 42 {
+		t.Fatalf("Compute set = (%d,%v), want (42,true)", next, ok)
+	}
+	if v, _ := m.Get("k"); v != 42 {
+		t.Fatalf("Get(k) after Compute = %d, want 42", v)
+	}
+
+	// Update existing.
+	next, ok = m.Compute("k", func(prev int, present bool) (int, bool) {
+		if !present || prev != 42 {
+			t.Fatalf("unexpected prev=%d present=%v", prev, present)
+		}
+		return prev + 1, false
+	})
+	if !ok || next != 43 {
+		t.Fatalf("Compute update = (%d,%v), want (43,true)", next, ok)
+	}
+
+	// Delete via Compute.
+	_, ok = m.Compute("k", func(prev int, present bool) (int, bool) {
+		if !present || prev != 43 {
+			t.Fatalf("unexpected prev=%d present=%v", prev, present)
+		}
+		return 0, true // delete
+	})
+	if ok {
+		t.Fatalf("Compute delete returned ok=true, want false")
+	}
+	if _, present := m.Get("k"); present {
+		t.Fatalf("key k still present after delete")
+	}
+}
+
+func TestNilReceiverMapInitializationPaths(t *testing.T) {
+	// Intentionally construct with nil underlying map and call methods that
+	// should auto-init (Set, LoadOrStore, Compute).
+	var m SafeMap[int, string] // m.m == nil
+
+	// Set path initializes map.
+	m.Set(1, "a")
+	if v, ok := m.Get(1); !ok || v != "a" {
+		t.Fatalf("Set/Get on nil map failed, got (%q,%v)", v, ok)
+	}
+
+	// LoadOrStore path uses existing value, does not overwrite.
+	if v, loaded := m.LoadOrStore(1, "b"); v != "a" || !loaded {
+		t.Fatalf("LoadOrStore on existing = (%q,%v), want (\"a\",true)", v, loaded)
+	}
+
+	// Compute path can set new key and later delete.
+	if v, ok := m.Compute(2, func(prev string, present bool) (string, bool) {
+		if present {
+			t.Fatalf("present unexpectedly true")
+		}
+		return "x", false
+	}); !ok || v != "x" {
+		t.Fatalf("Compute set on nil map failed, got (%q,%v)", v, ok)
+	}
+	if _, ok := m.Compute(2, func(prev string, present bool) (string, bool) {
+		if !present || prev != "x" {
+			t.Fatalf("unexpected prev=%q present=%v", prev, present)
+		}
+		return "", true // delete
+	}); ok {
+		t.Fatalf("Compute delete returned ok=true, want false")
+	}
+	if _, ok := m.Get(2); ok {
+		t.Fatalf("key 2 still present after delete")
+	}
+}
+
+func TestClear(t *testing.T) {
+	m := New[int, int]()
+	for i := 0; i < 5; i++ {
+		m.Set(i, i*i)
+	}
+	if m.Len() != 5 {
+		t.Fatalf("precondition Len() = %d, want 5", m.Len())
+	}
+	m.Clear()
+	if m.Len() != 0 {
+		t.Fatalf("Len() after Clear = %d, want 0", m.Len())
+	}
+
+	// After Clear, map remains usable.
+	m.Set(1, 2)
+	if v, ok := m.Get(1); !ok || v != 2 {
+		t.Fatalf("Get after Clear = (%d,%v), want (2,true)", v, ok)
+	}
+}
+
+func TestConcurrentSetGet(t *testing.T) {
+	const (
+		NWriters = 8
+		NReads   = 2000
+		NKeys    = 128
+	)
+	m := New[int, int]()
+	var wg sync.WaitGroup
+
+	// Writers
+	for i := 0; i < NWriters; i++ {
+		wg.Add(1)
+		go func(offset int) {
+			defer wg.Done()
+			for k := 0; k < NKeys; k++ {
+				m.Set(k, k+offset)
+			}
+		}(i)
+	}
+
+	// Readers
+	for i := 0; i < NWriters; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < NReads; i++ {
+				// Iterate via Range snapshot; also hit Get path.
+				sum := 0
+				m.Range(func(k, v int) bool {
+					sum += v
+					_, _ = m.Get(k)
+					return true
+				})
+				_ = sum // keep compiler happy
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Sanity: keys should exist (last writer wins, so we can't assert values).
+	keys := m.Keys()
+	if len(keys) == 0 {
+		t.Fatalf("no keys present after concurrent writes")
+	}
+
+	// Validate that m contains a subset/superset relationship with a fresh snapshot of its own map.
+	// This mainly ensures SafeMap is internally consistent.
+	check := make(map[int]int)
+	m.Range(func(k, v int) bool {
+		check[k] = v
+		return true
+	})
+	if !maps.EqualFunc(check, map[int]int{}, func(a, b int) bool { return true }) && len(check) == 0 {
+		t.Fatalf("inconsistent snapshot observed")
+	}
+}


### PR DESCRIPTION
- adds two new pollers, one that tracks cometbft rpcs in a map and another that dials peers for cometbft
- also adds a new smartmap package for maps that have an internal rw lock for safe reads and writes

this works in dev but they already peer with each other well so we probably want to see this on stage first