### PR TITLE
Set runtime environment before ssRpcServers

### DIFF
--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -191,6 +191,7 @@ func ReadConfig(logger *common.Logger) (*Config, error) {
 	cfg.AttDeregistrationRSize = 10
 
 	cfg.LogLevel = GetEnvWithDefault("AUDIUSD_LOG_LEVEL", "info")
+	cfg.Environment = GetRuntimeEnvironment()
 
 	ssRpcServers := ""
 	switch cfg.Environment {
@@ -209,7 +210,6 @@ func ReadConfig(logger *common.Logger) (*Config, error) {
 		RPCServers:     strings.Split(GetEnvWithDefault("stateSyncRPCServers", ssRpcServers), ","),
 	}
 
-	cfg.Environment = GetRuntimeEnvironment()
 	cfg.EthRPCUrl = GetEthRPC()
 
 	// check if discovery specific key is set


### PR DESCRIPTION
ssRpcServers config was getting initialized before the Environment config, so the switch statement was useless.