### PR TITLE
Fix links in proposal description

### DIFF
--- a/pkg/core/console/views/pages/adjudicate_page.templ
+++ b/pkg/core/console/views/pages/adjudicate_page.templ
@@ -84,7 +84,7 @@ Additional Proofs
         props.Slash.Signature,
         strippedEndpoint(props.ReportingEndpoint.Endpoint),
         fmt.Sprintf(
-            "%s/adjudicate/%s%s",
+            "%s/console/adjudicate/%s?%s",
             props.ReportingEndpoint.Endpoint,
             props.ServiceProvider.Address,
             getTimeRangeQueryString(props.StartTime, props.EndTime),

--- a/pkg/core/console/views/pages/adjudicate_page_templ.go
+++ b/pkg/core/console/views/pages/adjudicate_page_templ.go
@@ -92,7 +92,7 @@ Additional Proofs
 		props.Slash.Signature,
 		strippedEndpoint(props.ReportingEndpoint.Endpoint),
 		fmt.Sprintf(
-			"%s/adjudicate/%s%s",
+			"%s/console/adjudicate/%s?%s",
 			props.ReportingEndpoint.Endpoint,
 			props.ServiceProvider.Address,
 			getTimeRangeQueryString(props.StartTime, props.EndTime),


### PR DESCRIPTION
This just fixes the URL formatting. The proofs still match when using the correct url.