### PR TITLE
Remove 'context canceled' non-error

### DIFF
--- a/pkg/eth/eth.go
+++ b/pkg/eth/eth.go
@@ -355,7 +355,8 @@ func (eth *EthService) startEthDataManager(ctx context.Context) error {
 				return fmt.Errorf("error gathering eth endpoints: %v", err)
 			}
 		case <-ctx.Done():
-			return errors.New("context canceled")
+			eth.logger.Info("eth context canceled")
+			return ctx.Err()
 		}
 	}
 }


### PR DESCRIPTION
Removes error noise from axiom dashboard, more idiomatic to use context error anyway.