### PR TITLE
Fix parsing call data from governance proposals

### DIFF
--- a/pkg/eth/eth.go
+++ b/pkg/eth/eth.go
@@ -770,17 +770,14 @@ func DecodeSlashProposalArguments(callData string) (address ethcommon.Address, a
 
 	// Get bound method
 	data := ethcommon.FromHex(callData)
-	method, err := parsedABI.MethodById(data[:4])
-	if err != nil || method == nil {
-		return address, amount, fmt.Errorf("failed to get method from proposal call data: %v", err)
-	}
-	if method.Name != "slash" {
-		return address, amount, errors.New("got wrong method from proposal call data")
+	method, ok := parsedABI.Methods["slash"]
+	if !ok {
+		return address, amount, errors.New("failed to get slash method DelegateManager contract")
 	}
 
 	// Decode arguments
 	args := map[string]interface{}{}
-	err = method.Inputs.UnpackIntoMap(args, data[4:])
+	err = method.Inputs.UnpackIntoMap(args, data)
 	if err != nil {
 		return address, amount, fmt.Errorf("failed unpack arguments: %v", err)
 	}

--- a/pkg/integration_tests/00_slash_proposal_test.go
+++ b/pkg/integration_tests/00_slash_proposal_test.go
@@ -61,13 +61,16 @@ func TestCanRetrieveSlashProposal(t *testing.T) {
 	delegateManagerABI, err := gen.DelegateManagerMetaData.GetAbi()
 	require.NoError(t, err, "failed to get governance abi")
 
+	slashMethod, ok := delegateManagerABI.Methods["slash"]
+	require.True(t, ok, "could not retrieve slash method from DelegateManager abi")
+
 	contentThreeAddr := ethcommon.HexToAddress(contentThreeAddress)
 
-	callData1, err := delegateManagerABI.Pack("slash", big.NewInt(10), contentThreeAddr)
+	callData1, err := slashMethod.Inputs.Pack(contracts.AudioToWei(big.NewInt(10)), contentThreeAddr)
 	require.NoError(t, err, "failed to pack callData1")
-	callData2, err := delegateManagerABI.Pack("slash", big.NewInt(100), contentThreeAddr)
+	callData2, err := slashMethod.Inputs.Pack(contracts.AudioToWei(big.NewInt(100000)), contentThreeAddr)
 	require.NoError(t, err, "failed to pack callData2")
-	callData3, err := delegateManagerABI.Pack("slash", big.NewInt(5), contentThreeAddr)
+	callData3, err := slashMethod.Inputs.Pack(contracts.AudioToWei(big.NewInt(5)), contentThreeAddr)
 	require.NoError(t, err, "failed to pack callData3")
 
 	_, err = governanceContract.SubmitProposal(
@@ -117,5 +120,5 @@ func TestCanRetrieveSlashProposal(t *testing.T) {
 	slashAddr, slashAmount, err := eth.DecodeSlashProposalArguments(resp.Msg.CallData)
 	require.NoError(t, err, "failed to decode slash proposal arguments")
 	require.Equal(t, slashAddr.Cmp(contentThreeAddr), 0)
-	require.Equal(t, slashAmount.Int64(), int64(100))
+	require.Equal(t, contracts.WeiToAudio(slashAmount).Int64(), int64(100000))
 }


### PR DESCRIPTION
Governance proposals do not include the method ID when converting call data to ABI-compatible hex. This fixes our parsing in the eth service so that it does not expect a method ID in the first four bytes of call data.

Tests have also been updated to reflect the lack of 4-byte method IDs in the call data.