### PR TITLE
trimPrefix

### DIFF
--- a/pkg/core/server/eip712.go
+++ b/pkg/core/server/eip712.go
@@ -109,7 +109,7 @@ func RecoverPubkeyFromCoreTx(config *config.Config, em *v1.ManageEntityLegacy) (
 }
 
 func toBytes(str string) []byte {
-	v, _ := hex.DecodeString(strings.TrimLeft(str, "0x"))
+	v, _ := hex.DecodeString(strings.TrimPrefix(str, "0x"))
 	return v
 }
 


### PR DESCRIPTION
Some users have a signature that starts with 0 and/or x in the front. The way that go's TrimLeft works is that it would remove not just 0x but 0x0.. etc. This caused sporadic user create failures on production that were difficult to track. Trim Prefix to just capture the initial 0x is what should be used. This likely is what caused issues with comms pubkey recovery up to this point.

from claude
```
 - strings.TrimPrefix("0x08c9366a...", "0x") removes the "0x" prefix once and returns "08c9366a..."
  - strings.TrimLeft("0x08c9366a...", "0x") removes ALL leading '0' and 'x' characters, so it would return "8c9366a..." (notice the leading '0' from
  '08' is gone!)

  The prod2 signature starts with "0x08c9366a..." - the TrimLeft was incorrectly stripping the leading '0' from '08', making the hex string one
  character shorter (129 chars instead of 130). When decoded, this gave us 64 bytes instead of 65, causing the "invalid signature length" error.

  The prod and stage tests worked because their signatures don't start with '0' after the '0x' prefix:
  - prod: "0xd654..."
  - stage: "0x2177..."
```