### PR TITLE
Fix no default storage value

### DIFF
--- a/pkg/mediorum/server/monitor.go
+++ b/pkg/mediorum/server/monitor.go
@@ -25,7 +25,7 @@ type StorageAndDbSize struct {
 	DbUsed             uint64    `gorm:"not null"`
 	MediorumDiskUsed   uint64    `gorm:"not null"`
 	MediorumDiskSize   uint64    `gorm:"not null"`
-	StorageExpectation uint64    `gorm:"not null"`
+	StorageExpectation uint64    `gorm:"not null;default:0"`
 	LastRepairSize     int64     `gorm:"not null"`
 	LastCleanupSize    int64     `gorm:"not null"`
 }


### PR DESCRIPTION
In #208 , I added this field.

I didn't really understand how mediorum does things, but essentially it uses this struct and gorm to automatically create the migration to add the column storage_expectation to the storage_and_db_sizes table.

Without setting default:0, the non-null requirement doesn't work and crashes, preventing mediorum from coming up.

```
06:50:23 ERROR ERROR: column "storage_expectation" of relation "storage_and_db_sizes" contains null values (SQLSTATE 23502) error="ERROR: column \"storage_expectation\" of relation \"storage_and_db_sizes\" contains null values (SQLSTATE 23502)" query="ALTER TABLE \"storage_and_db_sizes\" ADD \"storage_expectation\" bigint NOT NULL" duration=5.248726ms rows=0 file=github.com/AudiusProject/audiusd/pkg/mediorum/server/db.go:150
```