### PR TITLE
As/comet forward

### DIFF
--- a/cmd/audiusd/env/dev.env
+++ b/cmd/audiusd/env/dev.env
@@ -2,4 +2,3 @@ MEDIORUM_ENV=dev
 audius_core_root_dir=/audius-core
 uptimeDataDir=/bolt
 AUDIUSD_PGALL=true
-stateSyncServeSnapshots=true

--- a/dev/env/audiusd-1.env
+++ b/dev/env/audiusd-1.env
@@ -8,3 +8,4 @@ audius_delegate_private_key=d09ba371c359f10f22ccda12fd26c598c7921bda3220c9942174
 audius_discprov_env=dev
 externalAddress="audiusd-1:26656"
 archive=true
+stateSyncServeSnapshots=true

--- a/dev/env/audiusd-2.env
+++ b/dev/env/audiusd-2.env
@@ -12,3 +12,4 @@ archive=false
 retainHeight=10
 MEDIORUM_ENV=dev
 externalAddress="audiusd-2:26656"
+stateSyncServeSnapshots=true

--- a/dev/env/audiusd-ss.env
+++ b/dev/env/audiusd-ss.env
@@ -8,3 +8,4 @@ audius_discprov_env=dev
 externalAddress="audiusd-ss:26656"
 stateSyncEnable=true
 stateSyncRPCServers=https://node1.audiusd.devnet/core/crpc,https://node2.audiusd.devnet/core/crpc
+skipEthRegistration=true

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -142,6 +142,7 @@ type Config struct {
 
 	/* Feature flags */
 	ProgrammableDistributionEnabled bool
+	SkipEthRegistration             bool
 }
 
 func (c *Config) IsDev() bool {
@@ -196,6 +197,8 @@ func ReadConfig() (*Config, error) {
 	cfg.LogLevel = GetLogLevel()
 	cfg.Environment = GetRuntimeEnvironment()
 	cfg.ProgrammableDistributionEnabled = common.IsProgrammableDistributionEnabled(cfg.Environment)
+
+	cfg.SkipEthRegistration = GetEnvWithDefault("skipEthRegistration", "false") == "true"
 
 	ssRpcServers := ""
 	switch cfg.Environment {

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -31,9 +31,6 @@ const (
 	ModuleGraphQL = "graphql"
 )
 
-// once completely released, remove debug and comet
-var defaultModules = []string{ModuleConsole, ModuleDebug, ModulePprof, ModuleComet, ModuleGraphQL}
-
 type RollupInterval struct {
 	BlockInterval int
 }
@@ -176,6 +173,7 @@ func ReadConfig() (*Config, error) {
 	// comet config
 	cfg.CometLogLevel = GetEnvWithDefault("audius_comet_log_level", "statesync:info,p2p:none,mempool:none,rpc:none,*:error")
 	cfg.RootDir = GetEnvWithDefault("audius_core_root_dir", homeDir+"/.audiusd")
+	cfg.RPCladdr = GetEnvWithDefault("rpcLaddr", "unix:///tmp/cometbft.rpc.sock")
 	cfg.P2PLaddr = GetEnvWithDefault("p2pLaddr", "tcp://0.0.0.0:26656")
 
 	cfg.GRPCladdr = GetEnvWithDefault("grpcLaddr", "0.0.0.0:50051")

--- a/pkg/core/config/setup.go
+++ b/pkg/core/config/setup.go
@@ -177,8 +177,14 @@ func SetupNode(logger *zap.Logger) (*Config, *cconfig.Config, error) {
 	cometConfig.P2P.PersistentPeersMaxDialPeriod = 15 * time.Second
 
 	// connection settings
-	if envConfig.RPCladdr != "" {
-		cometConfig.RPC.ListenAddress = envConfig.RPCladdr
+	// Only enable RPC if state sync serving is enabled
+	if envConfig.StateSync.ServeSnapshots {
+		if envConfig.RPCladdr != "" {
+			cometConfig.RPC.ListenAddress = envConfig.RPCladdr
+		}
+	} else {
+		// Disable RPC entirely when not serving state sync
+		cometConfig.RPC.ListenAddress = ""
 	}
 	if envConfig.P2PLaddr != "" {
 		cometConfig.P2P.ListenAddress = envConfig.P2PLaddr

--- a/pkg/core/config/setup.go
+++ b/pkg/core/config/setup.go
@@ -17,6 +17,7 @@ import (
 )
 
 const PrivilegedServiceSocket = "/tmp/cometbft.privileged.sock"
+const CometRPCSocket = "/tmp/cometbft.rpc.sock"
 
 func ensureSocketNotExists(socketPath string) error {
 	if _, err := os.Stat(socketPath); err == nil {
@@ -182,6 +183,9 @@ func SetupNode(logger *zap.Logger) (*Config, *cconfig.Config, error) {
 	if envConfig.P2PLaddr != "" {
 		cometConfig.P2P.ListenAddress = envConfig.P2PLaddr
 	}
+
+	// Clean up old sockets if they exist
+	ensureSocketNotExists(CometRPCSocket)
 
 	if !envConfig.Archive {
 		ensureSocketNotExists(PrivilegedServiceSocket)

--- a/pkg/core/server/comet_api.go
+++ b/pkg/core/server/comet_api.go
@@ -2,8 +2,9 @@
 package server
 
 import (
+	"bytes"
 	"context"
-	"errors"
+	"encoding/json"
 	"io"
 	"net"
 	"net/http"
@@ -11,13 +12,82 @@ import (
 	"time"
 
 	"github.com/AudiusProject/audiusd/pkg/core/config"
+	rpctypes "github.com/cometbft/cometbft/rpc/jsonrpc/types"
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
 )
 
+// allowedMethods defines the allowed RPC methods for state sync
+// This is read-only after initialization, making it safe for concurrent access
+var allowedMethods = map[string]struct{}{
+	"status":           {},
+	"block":            {},
+	"commit":           {},
+	"validators":       {},
+	"consensus_params": {}, // Required for state sync to fetch consensus parameters
+	"health":           {},
+}
+
+// maxRequestBodySize limits request size to 64KB - RPC requests should be tiny
+const maxRequestBodySize = 64 * 1024
+
 func (s *Server) proxyCometRequest(c echo.Context) error {
 	if !s.config.StateSync.ServeSnapshots {
-		return errors.New("")
+		return respondWithError(c, http.StatusForbidden, "state sync not enabled")
+	}
+
+	// Only allow GET and POST methods
+	if c.Request().Method != "GET" && c.Request().Method != "POST" {
+		return respondWithError(c, http.StatusMethodNotAllowed, "method not allowed")
+	}
+
+	// Handle validation based on request method
+	var bodyToForward io.Reader = c.Request().Body
+
+	if c.Request().Method == "POST" {
+		// Read the body to validate JSONRPC method (with size limit)
+		body, err := io.ReadAll(io.LimitReader(c.Request().Body, maxRequestBodySize))
+		if err != nil {
+			s.logger.Error("failed to read request body", zap.Error(err))
+			return respondWithError(c, http.StatusBadRequest, "failed to read request")
+		}
+
+		// Check if request was too large (if we read exactly the limit, there might be more)
+		if len(body) == maxRequestBodySize {
+			s.logger.Warn("request body too large", zap.Int("size", len(body)))
+			return respondWithError(c, http.StatusRequestEntityTooLarge, "request body too large")
+		}
+
+		// Parse JSONRPC request
+		var rpcReq rpctypes.RPCRequest
+		if err := json.Unmarshal(body, &rpcReq); err != nil {
+			s.logger.Error("failed to parse JSONRPC request", zap.Error(err))
+			return respondWithError(c, http.StatusBadRequest, "invalid JSONRPC request")
+		}
+
+		// Check if method is allowed
+		if _, ok := allowedMethods[rpcReq.Method]; !ok {
+			s.logger.Warn("blocked unauthorized RPC method",
+				zap.String("method", rpcReq.Method))
+			return respondWithError(c, http.StatusForbidden, "RPC method not allowed")
+		}
+
+		// Create new reader from body for forwarding
+		bodyToForward = bytes.NewReader(body)
+	} else if c.Request().Method == "GET" {
+		// For GET requests, check the path
+		rpcPath := strings.TrimPrefix(c.Request().RequestURI, "/core/crpc")
+		basePath := strings.TrimPrefix(rpcPath, "/")
+		if idx := strings.Index(basePath, "?"); idx != -1 {
+			basePath = basePath[:idx]
+		}
+
+		// Check if method is allowed
+		if _, ok := allowedMethods[basePath]; !ok {
+			s.logger.Warn("blocked unauthorized RPC method",
+				zap.String("method", basePath))
+			return respondWithError(c, http.StatusForbidden, "RPC method not allowed")
+		}
 	}
 
 	// Create HTTP client with Unix socket transport
@@ -36,7 +106,7 @@ func (s *Server) proxyCometRequest(c echo.Context) error {
 	// For Unix sockets, the host is ignored, but we need to provide one
 	path := "http://localhost" + strings.TrimPrefix(c.Request().RequestURI, "/core/crpc")
 
-	req, err := http.NewRequest(c.Request().Method, path, c.Request().Body)
+	req, err := http.NewRequest(c.Request().Method, path, bodyToForward)
 	if err != nil {
 		s.logger.Error("failed to create internal comet api request", zap.Error(err))
 		return respondWithError(c, http.StatusInternalServerError, "failed to create internal comet request")
@@ -62,8 +132,19 @@ func (s *Server) proxyCometRequest(c echo.Context) error {
 }
 
 func copyHeaders(source http.Header, destination http.Header) {
+	// Only copy safe headers for RPC requests
+	safeHeaders := map[string]bool{
+		"Content-Type":  true,
+		"Accept":        true,
+		"Cache-Control": true,
+		"User-Agent":    true,
+	}
+
 	for k, v := range source {
-		destination[k] = v
+		// Only copy whitelisted headers
+		if safeHeaders[k] {
+			destination[k] = v
+		}
 	}
 }
 

--- a/pkg/core/server/comet_api.go
+++ b/pkg/core/server/comet_api.go
@@ -1,152 +1,72 @@
+// Request forward for the internal cometbft rpc. Debug info and to be turned off by default.
 package server
 
 import (
-	"encoding/json"
+	"context"
+	"errors"
+	"io"
+	"net"
 	"net/http"
-	"strconv"
+	"strings"
+	"time"
 
+	"github.com/AudiusProject/audiusd/pkg/core/config"
 	"github.com/labstack/echo/v4"
+	"go.uber.org/zap"
 )
 
-func (s *Server) registerCRPCRoutes(g *echo.Group) {
-	// Explicit REST-style endpoints
-	g.GET("/crpc/status", s.getStatus)
-	g.GET("/crpc/health", s.getHealth)
-	g.GET("/crpc/block", s.getBlock)
-
-	// JSON-RPC endpoint
-	g.POST("/crpc", s.handleJSONRPC)
-}
-
-// ---------- Plain GET endpoints ----------
-
-func (s *Server) getStatus(c echo.Context) error {
-	ctx := c.Request().Context()
-	res, err := s.rpc.Status(ctx)
-	if err != nil {
-		return respondWithError(c, 502, err.Error())
-	}
-	return c.JSON(http.StatusOK, wrapJSONRPC(res))
-}
-
-func (s *Server) getHealth(c echo.Context) error {
-	ctx := c.Request().Context()
-	res, err := s.rpc.Health(ctx)
-	if err != nil {
-		return respondWithError(c, 502, err.Error())
-	}
-	return c.JSON(http.StatusOK, wrapJSONRPC(res))
-}
-
-func (s *Server) getBlock(c echo.Context) error {
-	ctx := c.Request().Context()
-	heightParam := c.QueryParam("height")
-
-	var height *int64
-	if heightParam != "" {
-		h, err := strconv.ParseInt(heightParam, 10, 64)
-		if err != nil {
-			return respondWithError(c, 400, "invalid height")
-		}
-		height = &h
+func (s *Server) proxyCometRequest(c echo.Context) error {
+	if !s.config.StateSync.ServeSnapshots {
+		return errors.New("")
 	}
 
-	res, err := s.rpc.Block(ctx, height)
-	if err != nil {
-		return respondWithError(c, 502, err.Error())
-	}
-	return c.JSON(http.StatusOK, wrapJSONRPC(res))
-}
-
-// ---------- JSON-RPC endpoint ----------
-
-func (s *Server) handleJSONRPC(c echo.Context) error {
-	ctx := c.Request().Context()
-
-	var req struct {
-		JSONRPC string          `json:"jsonrpc"`
-		ID      any             `json:"id"`
-		Method  string          `json:"method"`
-		Params  json.RawMessage `json:"params"`
-	}
-	if err := c.Bind(&req); err != nil {
-		return respondWithError(c, 400, "bad request")
-	}
-
-	switch req.Method {
-	case "status":
-		res, err := s.rpc.Status(ctx)
-		if err != nil {
-			return respondWithError(c, 502, err.Error())
-		}
-		return c.JSON(http.StatusOK, newJSONRPCResponse(req.ID, res))
-
-	case "health":
-		res, err := s.rpc.Health(ctx)
-		if err != nil {
-			return respondWithError(c, 502, err.Error())
-		}
-		return c.JSON(http.StatusOK, newJSONRPCResponse(req.ID, res))
-
-	case "block":
-		var params []any
-		_ = json.Unmarshal(req.Params, &params)
-
-		var height *int64
-		if len(params) > 0 {
-			switch v := params[0].(type) {
-			case float64:
-				h := int64(v)
-				height = &h
-			case string:
-				if h, err := strconv.ParseInt(v, 10, 64); err == nil {
-					height = &h
-				}
-			}
-		}
-		res, err := s.rpc.Block(ctx, height)
-		if err != nil {
-			return respondWithError(c, 502, err.Error())
-		}
-		return c.JSON(http.StatusOK, newJSONRPCResponse(req.ID, res))
-
-	default:
-		return c.JSON(http.StatusOK, map[string]any{
-			"jsonrpc": "2.0",
-			"id":      req.ID,
-			"error": map[string]any{
-				"code":    -32601,
-				"message": "method not found",
+	// Create HTTP client with Unix socket transport
+	httpClient := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				dialer := net.Dialer{}
+				return dialer.DialContext(ctx, "unix", config.CometRPCSocket)
 			},
-		})
+		},
+	}
+
+	s.logger.Info("request", zap.String("socket", config.CometRPCSocket), zap.String("method", c.Request().Method), zap.String("url", c.Request().RequestURI))
+
+	// For Unix sockets, the host is ignored, but we need to provide one
+	path := "http://localhost" + strings.TrimPrefix(c.Request().RequestURI, "/core/crpc")
+
+	req, err := http.NewRequest(c.Request().Method, path, c.Request().Body)
+	if err != nil {
+		s.logger.Error("failed to create internal comet api request", zap.Error(err))
+		return respondWithError(c, http.StatusInternalServerError, "failed to create internal comet request")
+	}
+
+	copyHeaders(c.Request().Header, req.Header)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		s.logger.Error("failed to forward comet api request", zap.Error(err))
+		return respondWithError(c, http.StatusInternalServerError, "failed to forward request")
+	}
+	defer resp.Body.Close()
+
+	c.Response().Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+	c.Response().WriteHeader(resp.StatusCode)
+	_, err = io.Copy(c.Response().Writer, resp.Body)
+	if err != nil {
+		return respondWithError(c, http.StatusInternalServerError, "failed to stream response")
+	}
+
+	return nil
+}
+
+func copyHeaders(source http.Header, destination http.Header) {
+	for k, v := range source {
+		destination[k] = v
 	}
 }
 
-// ---------- Helpers ----------
-
-func newJSONRPCResponse(id any, result any) map[string]any {
-	return map[string]any{
-		"jsonrpc": "2.0",
-		"id":      idOrDefault(id),
-		"result":  result,
-	}
-}
-
-func idOrDefault(id any) any {
-	if id == nil {
-		return -1
-	}
-	return id
-}
-
-func wrapJSONRPC(result any) map[string]any {
-	return map[string]any{
-		"jsonrpc": "2.0",
-		"id":      -1,
-		"result":  result,
-	}
-}
-
-func respondWithError(c echo.Context, status int, msg string) error {
-	return c.JSON(status, map[string]string{"error": msg})
+func respondWithError(c echo.Context, statusCode int, message string) error {
+	return c.JSON(statusCode, map[string]string{"error": message})
 }

--- a/pkg/core/server/http.go
+++ b/pkg/core/server/http.go
@@ -47,7 +47,7 @@ func (s *Server) startEchoServer(ctx context.Context) error {
 		return c.JSON(http.StatusOK, res.Msg)
 	})
 
-	s.registerCRPCRoutes(g)
+	g.Any("/crpc*", s.proxyCometRequest)
 	s.createEthRPC()
 
 	g.GET("/sdk", echo.WrapHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/core/server/registry_bridge.go
+++ b/pkg/core/server/registry_bridge.go
@@ -53,7 +53,7 @@ ethstatus:
 		}
 	}
 
-	if s.isDevEnvironment() {
+	if s.isDevEnvironment() && !s.config.SkipEthRegistration {
 		s.logger.Info("running in dev, registering on ethereum")
 		if err := s.registerSelfOnEth(ctx); err != nil {
 			s.logger.Error("error registering onto eth", zap.Error(err))


### PR DESCRIPTION
fixes state sync with cometbft forward
uses unix socket for internal rpc
only exposes rpc and specific methods required for state sync when state sync serving is on