### PR TITLE
rpc nil

### DIFF
--- a/pkg/core/server/connect.go
+++ b/pkg/core/server/connect.go
@@ -66,7 +66,7 @@ func (c *CoreService) GetNodeInfo(ctx context.Context, req *connect.Request[v1.G
 // ForwardTransaction implements v1connect.CoreServiceHandler.
 func (c *CoreService) ForwardTransaction(ctx context.Context, req *connect.Request[v1.ForwardTransactionRequest]) (*connect.Response[v1.ForwardTransactionResponse], error) {
 	// Check feature flag for programmable distribution features
-	if !c.core.config.ProgrammableDistributionEnabled {
+	if c.core != nil && c.core.config != nil && !c.core.config.ProgrammableDistributionEnabled {
 		// Check if transaction uses programmable distribution features
 		if req.Msg != nil && req.Msg.Transaction != nil && req.Msg.Transaction.GetFileUpload() != nil {
 			return nil, connect.NewError(connect.CodeUnimplemented, errors.New("programmable distribution is not enabled in this environment"))
@@ -118,11 +118,10 @@ func (c *CoreService) ForwardTransaction(ctx context.Context, req *connect.Reque
 		c.core.logger.Debug("received forwarded tx", zap.Any("tx", req.Msg.Transaction))
 	}
 
-	if c.core.rpc == nil {
+	if c.core == nil || c.core.rpc == nil {
 		return nil, connect.NewError(connect.CodePermissionDenied, errors.New("local rpc not ready"))
 	}
 
-	// TODO: intake block deadline from request
 	status, err := c.core.rpc.Status(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("chain not healthy: %v", err)

--- a/pkg/core/server/connect.go
+++ b/pkg/core/server/connect.go
@@ -675,6 +675,9 @@ func (c *CoreService) SendTransaction(ctx context.Context, req *connect.Request[
 
 // Utilities
 func (c *CoreService) getBlockRpcFallback(ctx context.Context, height int64) (*connect.Response[v1.GetBlockResponse], error) {
+	if c.core.rpc == nil {
+		return nil, errors.New("rpc not available")
+	}
 	block, err := c.core.rpc.Block(ctx, &height)
 	if err != nil {
 		blockInFutureMsg := "must be less than or equal to the current blockchain height"

--- a/pkg/core/server/connect.go
+++ b/pkg/core/server/connect.go
@@ -118,6 +118,10 @@ func (c *CoreService) ForwardTransaction(ctx context.Context, req *connect.Reque
 		c.core.logger.Debug("received forwarded tx", zap.Any("tx", req.Msg.Transaction))
 	}
 
+	if c.core.rpc == nil {
+		return nil, connect.NewError(connect.CodePermissionDenied, errors.New("local rpc not ready"))
+	}
+
 	// TODO: intake block deadline from request
 	status, err := c.core.rpc.Status(ctx)
 	if err != nil {


### PR DESCRIPTION
rpc can be nil on startup, it's safe to return an error here because this is ForwardTransaction